### PR TITLE
Fix library idle player alignment

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,7 +71,11 @@ function App() {
           {desktopMode === "library" ? (
             <div className="grid h-full min-h-0 w-full gap-4 lg:grid-cols-[minmax(300px,360px)_minmax(0,1fr)] xl:gap-6 xl:grid-cols-[minmax(340px,400px)_minmax(0,1fr)]">
               <div className="flex h-full min-h-0 flex-col gap-4 xl:gap-6">
-                <PlayerSection sidebarMode onSearchClick={handleSearchOpen} />
+                <PlayerSection
+                  sidebarMode
+                  idleVariant="sidebar"
+                  onSearchClick={handleSearchOpen}
+                />
               </div>
               <div className="h-full min-h-0">
                 <LibraryView />
@@ -79,7 +83,7 @@ function App() {
             </div>
           ) : isDesktopIdle ? (
             <div className="mx-auto flex h-full w-full max-w-[1180px] min-h-0 items-center justify-center">
-              <PlayerSection isIdle onSearchClick={handleSearchOpen} />
+              <PlayerSection idleVariant="hero" onSearchClick={handleSearchOpen} />
             </div>
           ) : (
             <>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -6,6 +6,13 @@ import { api, type SystemInfoResponse } from "@/services/api";
 import { frontendAppMetadata } from "@/lib/app-metadata";
 import { getVersionBadgeVariant } from "@/utils/version";
 import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 interface HeaderProps {
   onSearchClick?: () => void;
@@ -15,6 +22,7 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
   const desktopMode = useAppUiStore((state) => state.desktopMode);
   const setDesktopMode = useAppUiStore((state) => state.setDesktopMode);
   const [backendInfo, setBackendInfo] = useState<SystemInfoResponse | null>(null);
+  const [isVersionDialogOpen, setIsVersionDialogOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -42,98 +50,136 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
     `Backend ${backendInfo?.buildVersion ?? "loading..."}`,
   ].join(" | ");
 
+  const renderVersionBadgeButton = (className?: string) => (
+    <button
+      type="button"
+      onClick={() => setIsVersionDialogOpen(true)}
+      className={className}
+      title={versionTooltip}
+      aria-label="查看版本資訊"
+    >
+      <Badge variant={versionBadgeVariant}>v{frontendAppMetadata.appVersion}</Badge>
+    </button>
+  );
+
   return (
-    <header className="border-b border-[color:var(--surface-border)] bg-[color:var(--surface-subtle)]/90 px-4 py-3 backdrop-blur-xl lg:px-6 lg:py-4">
-      <div className="mx-auto flex max-w-[1480px] items-center justify-between gap-4">
-        {/* Logo - 手機版縮小 */}
-        <div className="flex items-center gap-3">
-          <div className="hidden h-11 w-11 items-center justify-center rounded-2xl border border-[color:var(--surface-border)] bg-[var(--accent-soft)] text-[var(--accent)] shadow-sm lg:flex">
-            <Music2 className="h-5 w-5" />
-          </div>
-          <div>
-            <div className="flex items-center gap-2">
-              <h1 className="text-xl font-bold tracking-tight text-[var(--text-primary)] lg:text-[1.9rem]">
-                <span className="lg:hidden">🎵</span>{" "}
-                <span className="hidden sm:inline">YouTube Music Bot</span>
-              </h1>
-              <Badge
-                variant={versionBadgeVariant}
-                className="hidden sm:inline-flex"
-                title={versionTooltip}
-              >
-                v{frontendAppMetadata.appVersion}
-              </Badge>
+    <>
+      <header className="border-b border-[color:var(--surface-border)] bg-[color:var(--surface-subtle)]/90 px-4 py-3 backdrop-blur-xl lg:px-6 lg:py-4">
+        <div className="mx-auto flex max-w-[1480px] items-center justify-between gap-4">
+          {/* Logo - 手機版縮小 */}
+          <div className="flex items-center gap-3">
+            <div className="hidden h-11 w-11 items-center justify-center rounded-2xl border border-[color:var(--surface-border)] bg-[var(--accent-soft)] text-[var(--accent)] shadow-sm lg:flex">
+              <Music2 className="h-5 w-5" />
             </div>
-            <p className="hidden text-sm text-[var(--text-secondary)] lg:block">
-              Desktop jukebox with synced lyrics and live queue
-            </p>
+            <div>
+              <div className="flex items-center gap-2">
+                <h1 className="text-xl font-bold tracking-tight text-[var(--text-primary)] lg:text-[1.9rem]">
+                  <span className="lg:hidden">🎵</span>{" "}
+                  <span className="hidden sm:inline">YouTube Music Bot</span>
+                </h1>
+                {renderVersionBadgeButton("hidden sm:inline-flex")}
+              </div>
+              <p className="hidden text-sm text-[var(--text-secondary)] lg:block">
+                Desktop jukebox with synced lyrics and live queue
+              </p>
+            </div>
+          </div>
+
+          <div className="hidden lg:flex items-center rounded-[24px] border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] p-1">
+            <button
+              type="button"
+              onClick={() => setDesktopMode("player")}
+              className={`rounded-[18px] px-4 py-2.5 text-sm font-semibold transition-colors ${
+                desktopMode === "player"
+                  ? "bg-[var(--surface-elevated)] text-[var(--text-primary)] shadow-[0_12px_24px_-20px_var(--accent-glow)]"
+                  : "text-[var(--text-secondary)]"
+              }`}
+            >
+              播放中
+            </button>
+            <button
+              type="button"
+              onClick={() => setDesktopMode("library")}
+              className={`rounded-[18px] px-4 py-2.5 text-sm font-semibold transition-colors ${
+                desktopMode === "library"
+                  ? "bg-[var(--surface-elevated)] text-[var(--text-primary)] shadow-[0_12px_24px_-20px_var(--accent-glow)]"
+                  : "text-[var(--text-secondary)]"
+              }`}
+            >
+              媒體庫
+            </button>
+          </div>
+
+          <div className="flex items-center gap-2 lg:flex-1 lg:justify-end lg:gap-4">
+            {/* 搜尋按鈕 - 手機版隱藏 */}
+            <button
+              type="button"
+              onClick={onSearchClick}
+              className="desktop-command-button hidden min-w-[260px] items-center justify-between rounded-2xl border px-4 py-3 text-left transition-transform duration-200 hover:-translate-y-0.5 lg:flex"
+            >
+              <span className="flex items-center gap-3 text-[var(--text-primary)]">
+                <Search className="h-4 w-4 text-[var(--text-secondary)]" />
+                <span className="font-medium">搜尋音樂</span>
+              </span>
+              <kbd className="inline-flex h-7 select-none items-center gap-1 rounded-xl border border-[color:var(--surface-border)] bg-[var(--surface-muted)] px-2.5 font-mono text-xs text-[var(--text-secondary)]">
+                <span className="text-[0.65rem]">⌘</span>K
+              </kbd>
+            </button>
+
+            {/* GitHub 連結 */}
+            <a
+              href="https://github.com/bs10081/youtube-music-bot"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex h-10 w-10 items-center justify-center rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"
+              aria-label="前往 GitHub 專案"
+            >
+              <Github className="h-5 w-5" />
+            </a>
+
+            {/* 連線狀態 */}
+            <ConnectionStatus />
+
+            {renderVersionBadgeButton("sm:hidden")}
           </div>
         </div>
+      </header>
 
-        <div className="hidden lg:flex items-center rounded-[24px] border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] p-1">
-          <button
-            type="button"
-            onClick={() => setDesktopMode("player")}
-            className={`rounded-[18px] px-4 py-2.5 text-sm font-semibold transition-colors ${
-              desktopMode === "player"
-                ? "bg-[var(--surface-elevated)] text-[var(--text-primary)] shadow-[0_12px_24px_-20px_var(--accent-glow)]"
-                : "text-[var(--text-secondary)]"
-            }`}
-          >
-            播放中
-          </button>
-          <button
-            type="button"
-            onClick={() => setDesktopMode("library")}
-            className={`rounded-[18px] px-4 py-2.5 text-sm font-semibold transition-colors ${
-              desktopMode === "library"
-                ? "bg-[var(--surface-elevated)] text-[var(--text-primary)] shadow-[0_12px_24px_-20px_var(--accent-glow)]"
-                : "text-[var(--text-secondary)]"
-            }`}
-          >
-            媒體庫
-          </button>
-        </div>
+      <Dialog open={isVersionDialogOpen} onOpenChange={setIsVersionDialogOpen}>
+        <DialogContent className="w-[calc(100vw-2rem)] max-w-md p-0">
+          <div className="relative p-6">
+            <DialogClose />
+            <div className="space-y-5 pr-10">
+              <div className="space-y-2">
+                <DialogTitle>版本資訊</DialogTitle>
+                <DialogDescription>
+                  目前畫面與 API 實際回報的 build 版本，可直接拿來追蹤部署內容。
+                </DialogDescription>
+              </div>
 
-        <div className="flex items-center gap-2 lg:flex-1 lg:justify-end lg:gap-4">
-          {/* 搜尋按鈕 - 手機版隱藏 */}
-          <button
-            type="button"
-            onClick={onSearchClick}
-            className="desktop-command-button hidden min-w-[260px] items-center justify-between rounded-2xl border px-4 py-3 text-left transition-transform duration-200 hover:-translate-y-0.5 lg:flex"
-          >
-            <span className="flex items-center gap-3 text-[var(--text-primary)]">
-              <Search className="h-4 w-4 text-[var(--text-secondary)]" />
-              <span className="font-medium">搜尋音樂</span>
-            </span>
-            <kbd className="inline-flex h-7 select-none items-center gap-1 rounded-xl border border-[color:var(--surface-border)] bg-[var(--surface-muted)] px-2.5 font-mono text-xs text-[var(--text-secondary)]">
-              <span className="text-[0.65rem]">⌘</span>K
-            </kbd>
-          </button>
+              <div className="space-y-3">
+                <div className="surface-subtle rounded-2xl border border-[color:var(--surface-border)] p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                    Frontend
+                  </p>
+                  <p className="mt-2 break-all font-mono text-sm text-[var(--text-primary)]">
+                    {frontendAppMetadata.buildVersion}
+                  </p>
+                </div>
 
-          {/* GitHub 連結 */}
-          <a
-            href="https://github.com/bs10081/youtube-music-bot"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex h-10 w-10 items-center justify-center rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"
-            aria-label="前往 GitHub 專案"
-          >
-            <Github className="h-5 w-5" />
-          </a>
-
-          {/* 連線狀態 */}
-          <ConnectionStatus />
-
-          <Badge
-            variant={versionBadgeVariant}
-            className="sm:hidden"
-            title={versionTooltip}
-          >
-            v{frontendAppMetadata.appVersion}
-          </Badge>
-        </div>
-      </div>
-    </header>
+                <div className="surface-subtle rounded-2xl border border-[color:var(--surface-border)] p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                    Backend
+                  </p>
+                  <p className="mt-2 break-all font-mono text-sm text-[var(--text-primary)]">
+                    {backendInfo?.buildVersion ?? "loading..."}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };

--- a/frontend/src/components/player/NowPlaying.tsx
+++ b/frontend/src/components/player/NowPlaying.tsx
@@ -9,16 +9,18 @@ import { Heart, Library, Search, Sparkles } from "lucide-react";
 
 const EMPTY_FAVORITES: Array<{ videoId: string }> = [];
 
+export type PlayerIdleVariant = "hero" | "sidebar";
+
 interface NowPlayingProps {
   onSearchClick?: () => void;
-  showIdleState?: boolean;
+  idleVariant?: PlayerIdleVariant | null;
   compact?: boolean;
   sidebarMode?: boolean;
 }
 
 export const NowPlaying = ({
   onSearchClick,
-  showIdleState = true,
+  idleVariant = "hero",
   compact = false,
   sidebarMode = false,
 }: NowPlayingProps) => {
@@ -33,7 +35,7 @@ export const NowPlaying = ({
   const { showToast } = useToast();
 
   if (!currentTrack) {
-    if (!showIdleState) {
+    if (idleVariant === null) {
       return (
         <div className="flex flex-col items-center gap-6 text-center lg:items-start lg:text-left">
           <Avatar
@@ -54,6 +56,54 @@ export const NowPlaying = ({
               </p>
             </div>
           </div>
+        </div>
+      );
+    }
+
+    if (idleVariant === "sidebar") {
+      return (
+        <div className="flex flex-col gap-5 text-left">
+          <div className="flex items-start gap-4">
+            <Avatar
+              size="lg"
+              className="h-28 w-28 shrink-0 rounded-[24px] border border-[color:var(--dynamic-ring)] bg-[color:color-mix(in_srgb,var(--surface-elevated)_84%,var(--accent-soft)_16%)]"
+              fallback={<Sparkles className="h-10 w-10 text-[var(--text-muted)]" />}
+            />
+            <div className="min-w-0 space-y-3">
+              <span className="inline-flex rounded-full border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent)]">
+                Ready
+              </span>
+              <div className="space-y-2">
+                <p className="text-2xl font-semibold tracking-tight text-[var(--text-primary)] xl:text-[2rem]">
+                  從資料庫開始播放
+                </p>
+                <p className="text-sm leading-6 text-[var(--text-secondary)]">
+                  搜尋、開啟歌單或從收藏挑一首歌，播放器會保持在左側即時更新。
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              onClick={onSearchClick}
+              className="rounded-2xl shadow-[0_20px_34px_-18px_var(--accent-glow)]"
+            >
+              <Search className="h-4 w-4" />
+              搜尋音樂
+            </Button>
+            <div className="inline-flex h-11 items-center gap-2 rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] px-4 text-sm font-medium text-[var(--text-secondary)]">
+              <kbd className="inline-flex h-7 min-w-7 items-center justify-center rounded-xl border border-[color:var(--surface-border)] bg-[var(--surface-muted)] px-2 font-mono text-xs">
+                <span className="text-[0.65rem]">⌘</span>K
+              </kbd>
+              快速搜尋
+            </div>
+          </div>
+
+          <p className="text-sm leading-6 text-[var(--text-muted)]">
+            開始播放後，封面、控制與即將播放資訊會在這個側欄持續同步。
+          </p>
         </div>
       );
     }

--- a/frontend/src/components/player/PlayerSection.tsx
+++ b/frontend/src/components/player/PlayerSection.tsx
@@ -8,42 +8,40 @@ import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/ui/avatar";
 import { formatTime } from "@/utils/format";
 import { RadioToggleButton } from "./RadioToggleButton";
+import type { PlayerIdleVariant } from "./NowPlaying";
 
 interface PlayerSectionProps {
-  isIdle?: boolean;
   onSearchClick?: () => void;
   sidebarMode?: boolean;
+  idleVariant?: PlayerIdleVariant;
 }
 
 export const PlayerSection = ({
-  isIdle = false,
   onSearchClick,
   sidebarMode = false,
+  idleVariant = "hero",
 }: PlayerSectionProps) => {
   const currentTrack = usePlayerStore((state) => state.playbackState.currentTrack);
   const nextTrack = usePlayerStore((state) => state.playbackState.queue[0] ?? null);
   const queueLength = usePlayerStore((state) => state.playbackState.queue.length);
-  const shouldShowIdleLayout = isIdle || (!currentTrack && queueLength === 0);
-  const isSidebarPlayer = sidebarMode && !shouldShowIdleLayout;
+  const isPlaybackIdle = !currentTrack && queueLength === 0;
+  const isHeroIdle = isPlaybackIdle && idleVariant === "hero";
+  const isSidebarShell = sidebarMode && !isHeroIdle;
 
   return (
     <Card
       className={cn(
         "desktop-player-shell surface-card-strong min-h-0 overflow-hidden p-0",
-        shouldShowIdleLayout
-          ? "mx-auto w-full max-w-[920px]"
-          : isSidebarPlayer
-            ? "h-full w-full"
-            : "h-full",
+        isHeroIdle ? "mx-auto w-full max-w-[920px]" : "h-full w-full",
       )}
     >
       <div
         className={cn(
           "relative z-10 flex h-full min-h-0 flex-col overflow-y-auto",
-          !shouldShowIdleLayout && "desktop-scrollbar",
-          shouldShowIdleLayout
+          !isPlaybackIdle && "desktop-scrollbar",
+          isHeroIdle
             ? "min-h-[620px] px-8 py-12 lg:px-12 lg:py-14"
-            : isSidebarPlayer
+            : isSidebarShell
               ? "p-5 xl:p-6"
               : "p-5 lg:p-6 xl:p-8",
         )}
@@ -51,9 +49,9 @@ export const PlayerSection = ({
         <div
           className={cn(
             "mx-auto flex w-full min-h-0 flex-col",
-            shouldShowIdleLayout
+            isHeroIdle
               ? "max-w-[760px] justify-center gap-10"
-              : isSidebarPlayer
+              : isSidebarShell
                 ? "max-w-none gap-4 xl:gap-5"
                 : "max-w-[760px] gap-4 lg:gap-5 xl:gap-6",
           )}
@@ -61,16 +59,16 @@ export const PlayerSection = ({
           {/* 當前播放資訊 */}
           <NowPlaying
             onSearchClick={onSearchClick}
-            showIdleState={shouldShowIdleLayout}
-            compact={!shouldShowIdleLayout}
-            sidebarMode={isSidebarPlayer}
+            idleVariant={isPlaybackIdle ? idleVariant : null}
+            compact={!isHeroIdle}
+            sidebarMode={isSidebarShell}
           />
 
-          {!shouldShowIdleLayout ? (
+          {!isPlaybackIdle ? (
             <div
               className={cn(
                 "flex flex-col",
-                isSidebarPlayer ? "gap-4 pb-5 xl:pb-6" : "gap-5 pb-6 xl:gap-6 xl:pb-8",
+                isSidebarShell ? "gap-4 pb-5 xl:pb-6" : "gap-5 pb-6 xl:gap-6 xl:pb-8",
               )}
             >
               {/* 播放進度條 */}
@@ -80,13 +78,13 @@ export const PlayerSection = ({
               <div
                 className={cn(
                   "flex flex-col border-t border-[color:var(--surface-border)]",
-                  isSidebarPlayer ? "gap-4 pt-4" : "gap-4 pt-5 xl:gap-5 xl:pt-6",
+                  isSidebarShell ? "gap-4 pt-4" : "gap-4 pt-5 xl:gap-5 xl:pt-6",
                 )}
               >
                 <div
                   className={cn(
                     "surface-subtle rounded-[28px] border border-[color:var(--dynamic-ring)]",
-                    isSidebarPlayer ? "p-4" : "p-4 xl:p-5",
+                    isSidebarShell ? "p-4" : "p-4 xl:p-5",
                   )}
                 >
                   <div className="space-y-4">
@@ -107,7 +105,7 @@ export const PlayerSection = ({
                       <VolumeControl
                         className={cn(
                           "h-[56px] max-w-none",
-                          isSidebarPlayer ? "min-w-0 w-full" : "xl:min-w-[300px]",
+                          isSidebarShell ? "min-w-0 w-full" : "xl:min-w-[300px]",
                         )}
                       />
                     </div>

--- a/memory.md
+++ b/memory.md
@@ -1,0 +1,8 @@
+# Memory
+
+## 2026-03-17
+
+- Released version `0.2.1`.
+- Fixed issue `#7`: the desktop library page keeps the player sidebar aligned correctly when nothing is currently playing.
+- The header version badge is now clickable and opens a dialog showing the current frontend and backend build versions with short SHA identifiers.
+- The displayed app version comes from the root [`package.json`](/Users/bs10081/Developer/youtube_music_bot/package.json).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-music-bot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "YouTube Music 點歌機器人 WebUI",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- fix issue #7 where the desktop library page showed the full hero idle player instead of a sidebar-aligned empty state
- make the header version badge clickable so the current frontend and backend build versions are easy to inspect
- bump the app version to `0.2.1` and record the release note in `memory.md`

## Testing
- npm run build (frontend)
- bun test src/__tests__/version-metadata.test.ts src/__tests__/api.system.test.ts

Closes #7