### PR TITLE
Merge codex/dev into main for sync identity updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@ YTDLP_COOKIES_FILE="/app/secrets/youtube-cookies.txt"
 - `YTDLP_COOKIES_FILE`
   當 YouTube 對目前 IP 要求人類驗證時，可掛入已登入帳號匯出的 cookies 檔
 
-## 已知問題
-
-- 歌詞面板的「自動歸正到目前句中央」在重新整理頁面或重新回到瀏覽畫面後仍不穩定。
-- 目前切換到其他 tab（例如播放列表）再切回歌詞時，較容易重新對齊；這表示底層可見性 / layout 時序仍有待進一步修正。
-- 這個問題目前只先記錄狀態，尚未視為已修復功能。
-
 ## 系統架構
 
 ```

--- a/frontend/src/components/library/LibraryView.tsx
+++ b/frontend/src/components/library/LibraryView.tsx
@@ -1,5 +1,9 @@
-import { useMemo, useState, type ReactNode } from "react";
-import { useLibraryStore, getCurrentDevice } from "@/stores/libraryStore";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useLibraryStore,
+  getCurrentDevice,
+  getCurrentRequester,
+} from "@/stores/libraryStore";
 import { useToast } from "@/components/ui/toast";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -8,6 +12,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar } from "@/components/ui/avatar";
 import { api } from "@/services/api";
 import { formatTime } from "@/utils/format";
+import { formatDeviceDetail } from "@/utils/device-info";
 import { cn } from "@/lib/utils";
 import type {
   HistoryEntry,
@@ -52,6 +57,8 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
   const syncError = useLibraryStore((state) => state.syncError);
   const selectPlaylist = useLibraryStore((state) => state.selectPlaylist);
   const applySyncSession = useLibraryStore((state) => state.applySyncSession);
+  const updatePairedDevices = useLibraryStore((state) => state.updatePairedDevices);
+  const updateProfileName = useLibraryStore((state) => state.updateProfileName);
   const createPlaylist = useLibraryStore((state) => state.createPlaylist);
   const renamePlaylist = useLibraryStore((state) => state.renamePlaylist);
   const deletePlaylist = useLibraryStore((state) => state.deletePlaylist);
@@ -64,6 +71,9 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
   const [playlistName, setPlaylistName] = useState("");
   const [pairCodeInput, setPairCodeInput] = useState("");
   const [isPairing, setIsPairing] = useState(false);
+  const [profileNameInput, setProfileNameInput] = useState("未命名使用者");
+  const [isSavingProfileName, setIsSavingProfileName] = useState(false);
+  const [renamingDeviceId, setRenamingDeviceId] = useState<string | null>(null);
   const [editingPlaylistId, setEditingPlaylistId] = useState<string | null>(null);
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   const [activeSection, setActiveSection] = useState<LibrarySection>("playlists");
@@ -78,6 +88,7 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
     [selectedPlaylistId, snapshot?.playlists],
   );
   const currentDevice = getCurrentDevice(snapshot ?? null);
+  const currentRequester = getCurrentRequester(snapshot ?? null);
   const favoriteTrackIds = useMemo(
     () => new Set(snapshot?.favorites.map((favorite) => favorite.videoId) ?? []),
     [snapshot?.favorites],
@@ -119,6 +130,14 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
     );
   }, [normalizedQuery, snapshot?.history]);
 
+  useEffect(() => {
+    if (!snapshot) {
+      return;
+    }
+
+    setProfileNameInput(snapshot.profileName);
+  }, [snapshot?.profileName]);
+
   if (!ready || !snapshot) {
     return (
       <Card className="surface-card flex h-full items-center justify-center rounded-[32px] p-8">
@@ -137,6 +156,7 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
     const response = await api.playPlaylist(
       playlist.id,
       playlist.tracks.map((entry) => entry.track),
+      currentRequester,
     );
 
     if (response.success) {
@@ -151,6 +171,7 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
     const response = await api.queuePlaylist(
       playlist.id,
       playlist.tracks.map((entry) => entry.track),
+      currentRequester,
     );
 
     if (response.success) {
@@ -162,7 +183,7 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
   };
 
   const handleReplayMix = async (savedMix: SavedMix) => {
-    const response = await api.createMix(savedMix.seedTrack);
+    const response = await api.createMix(savedMix.seedTrack, currentRequester);
 
     if (response.success) {
       showToast({ message: "已重新啟動 Mix", type: "success" });
@@ -173,7 +194,7 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
   };
 
   const handleAddTrackToQueue = async (track: PlaylistTrackEntry["track"]) => {
-    const response = await api.addToQueue(track);
+    const response = await api.addToQueue(track, currentRequester);
 
     if (response.success) {
       showToast({ message: `已加入播放佇列：${track.title}`, type: "success" });
@@ -195,8 +216,10 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
         profileId: snapshot.profileId,
         device: {
           id: currentDevice.id,
-          name: currentDevice.name,
+          name: currentDevice.displayName,
           kind: currentDevice.kind,
+          reportedName: currentDevice.reportedName,
+          metadata: currentDevice.metadata,
         },
       });
 
@@ -208,11 +231,80 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
       await applySyncSession({
         ...response.data,
         pairCode: response.data.pairCode,
+        profileName:
+          String((response.data as { profileName?: unknown }).profileName ?? "").trim() ||
+          snapshot.profileName,
       });
       setPairCodeInput("");
       showToast({ message: "裝置已加入同步 session", type: "success" });
     } finally {
       setIsPairing(false);
+    }
+  };
+
+  const handleSaveProfileName = async () => {
+    if (!snapshot) {
+      return;
+    }
+
+    const nextName = profileNameInput.trim() || snapshot.profileName;
+    if (nextName === snapshot.profileName) {
+      return;
+    }
+
+    setIsSavingProfileName(true);
+    try {
+      if (!snapshot.syncSessionId) {
+        await updateProfileName(nextName);
+        showToast({ message: "已更新使用者名稱", type: "success" });
+        return;
+      }
+
+      const response = await api.updateSyncProfileName(
+        snapshot.syncSessionId,
+        nextName,
+      );
+      if (!response.success) {
+        showToast({ message: response.error || "更新使用者名稱失敗", type: "error" });
+        return;
+      }
+
+      await updateProfileName(response.data?.profileName ?? nextName);
+      showToast({ message: "已更新使用者名稱", type: "success" });
+    } finally {
+      setIsSavingProfileName(false);
+    }
+  };
+
+  const handleRenameDevice = async (deviceId: string, name: string) => {
+    if (!snapshot?.syncSessionId) {
+      return;
+    }
+
+    const nextName = name.trim();
+    if (!nextName) {
+      showToast({ message: "請輸入裝置名稱", type: "error" });
+      return;
+    }
+
+    setRenamingDeviceId(deviceId);
+    try {
+      const response = await api.renameSyncDevice(
+        snapshot.syncSessionId,
+        deviceId,
+        nextName,
+      );
+      if (!response.success) {
+        showToast({ message: response.error || "裝置重新命名失敗", type: "error" });
+        return;
+      }
+
+      if (response.data && Array.isArray(response.data.devices)) {
+        await updatePairedDevices(response.data.devices);
+      }
+      showToast({ message: "裝置名稱已更新", type: "success" });
+    } finally {
+      setRenamingDeviceId(null);
     }
   };
 
@@ -279,6 +371,11 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
         favoriteTrackIds={favoriteTrackIds}
         savedMixes={snapshot.savedMixes}
         pairedDevices={snapshot.pairedDevices}
+        profileName={snapshot.profileName}
+        profileNameInput={profileNameInput}
+        onProfileNameInputChange={setProfileNameInput}
+        onSaveProfileName={() => void handleSaveProfileName()}
+        isSavingProfileName={isSavingProfileName}
         syncPairCode={syncPairCode}
         syncStatus={syncStatus}
         syncError={syncError}
@@ -296,6 +393,8 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
           showToast({ message: "已從媒體庫移除 Mix", type: "success" });
         }}
         onRemoveDevice={(deviceId) => void handleRemoveDevice(deviceId)}
+        onRenameDevice={(deviceId, name) => void handleRenameDevice(deviceId, name)}
+        renamingDeviceId={renamingDeviceId}
         currentDeviceId={currentDevice?.id ?? null}
       />
     ) : (
@@ -315,6 +414,11 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
         favoriteTrackIds={favoriteTrackIds}
         savedMixes={snapshot.savedMixes}
         pairedDevices={snapshot.pairedDevices}
+        profileName={snapshot.profileName}
+        profileNameInput={profileNameInput}
+        onProfileNameInputChange={setProfileNameInput}
+        onSaveProfileName={() => void handleSaveProfileName()}
+        isSavingProfileName={isSavingProfileName}
         syncPairCode={syncPairCode}
         syncStatus={syncStatus}
         syncError={syncError}
@@ -332,6 +436,8 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
           showToast({ message: "已從媒體庫移除 Mix", type: "success" });
         }}
         onRemoveDevice={(deviceId) => void handleRemoveDevice(deviceId)}
+        onRenameDevice={(deviceId, name) => void handleRenameDevice(deviceId, name)}
+        renamingDeviceId={renamingDeviceId}
         currentDeviceId={currentDevice?.id ?? null}
         counts={{
           playlists: snapshot.playlists.length,
@@ -377,6 +483,11 @@ interface LibraryHomeBaseProps {
   favoriteTrackIds: Set<string>;
   savedMixes: SavedMix[];
   pairedDevices: PairedDevice[];
+  profileName: string;
+  profileNameInput: string;
+  onProfileNameInputChange: (value: string) => void;
+  onSaveProfileName: () => void;
+  isSavingProfileName: boolean;
   syncPairCode: string | null;
   syncStatus: "idle" | "connecting" | "connected" | "error";
   syncError: string | null;
@@ -391,6 +502,8 @@ interface LibraryHomeBaseProps {
   onReplayMix: (savedMix: SavedMix) => void;
   onDeleteMix: (mixId: string) => void | Promise<void>;
   onRemoveDevice: (deviceId: string) => void;
+  onRenameDevice: (deviceId: string, name: string) => void;
+  renamingDeviceId: string | null;
   currentDeviceId: string | null;
 }
 
@@ -417,6 +530,11 @@ const DesktopLibraryHome = ({
   favoriteTrackIds,
   savedMixes,
   pairedDevices,
+  profileName,
+  profileNameInput,
+  onProfileNameInputChange,
+  onSaveProfileName,
+  isSavingProfileName,
   syncPairCode,
   syncStatus,
   syncError,
@@ -431,6 +549,8 @@ const DesktopLibraryHome = ({
   onReplayMix,
   onDeleteMix,
   onRemoveDevice,
+  onRenameDevice,
+  renamingDeviceId,
   currentDeviceId,
   counts,
 }: DesktopLibraryHomeProps) => (
@@ -536,6 +656,11 @@ const DesktopLibraryHome = ({
       />
       <DevicesPanel
         pairedDevices={pairedDevices}
+        profileName={profileName}
+        profileNameInput={profileNameInput}
+        onProfileNameInputChange={onProfileNameInputChange}
+        onSaveProfileName={onSaveProfileName}
+        isSavingProfileName={isSavingProfileName}
         syncPairCode={syncPairCode}
         syncStatus={syncStatus}
         syncError={syncError}
@@ -544,6 +669,8 @@ const DesktopLibraryHome = ({
         isPairing={isPairing}
         onPairDevice={onPairDevice}
         onRemoveDevice={onRemoveDevice}
+        onRenameDevice={onRenameDevice}
+        renamingDeviceId={renamingDeviceId}
         currentDeviceId={currentDeviceId}
       />
     </div>
@@ -564,6 +691,11 @@ const MobileLibraryHome = ({
   favoriteTrackIds,
   savedMixes,
   pairedDevices,
+  profileName,
+  profileNameInput,
+  onProfileNameInputChange,
+  onSaveProfileName,
+  isSavingProfileName,
   syncPairCode,
   syncStatus,
   syncError,
@@ -578,6 +710,8 @@ const MobileLibraryHome = ({
   onReplayMix,
   onDeleteMix,
   onRemoveDevice,
+  onRenameDevice,
+  renamingDeviceId,
   currentDeviceId,
 }: LibraryHomeBaseProps) => (
   <div className="space-y-5">
@@ -657,6 +791,11 @@ const MobileLibraryHome = ({
     <DevicesPanel
       mobile
       pairedDevices={pairedDevices}
+      profileName={profileName}
+      profileNameInput={profileNameInput}
+      onProfileNameInputChange={onProfileNameInputChange}
+      onSaveProfileName={onSaveProfileName}
+      isSavingProfileName={isSavingProfileName}
       syncPairCode={syncPairCode}
       syncStatus={syncStatus}
       syncError={syncError}
@@ -665,6 +804,8 @@ const MobileLibraryHome = ({
       isPairing={isPairing}
       onPairDevice={onPairDevice}
       onRemoveDevice={onRemoveDevice}
+      onRenameDevice={onRenameDevice}
+      renamingDeviceId={renamingDeviceId}
       currentDeviceId={currentDeviceId}
     />
   </div>
@@ -1005,6 +1146,11 @@ const SavedMixPanel = ({
 
 const DevicesPanel = ({
   pairedDevices,
+  profileName,
+  profileNameInput,
+  onProfileNameInputChange,
+  onSaveProfileName,
+  isSavingProfileName,
   syncPairCode,
   syncStatus,
   syncError,
@@ -1013,10 +1159,17 @@ const DevicesPanel = ({
   isPairing,
   onPairDevice,
   onRemoveDevice,
+  onRenameDevice,
+  renamingDeviceId,
   currentDeviceId,
   mobile = false,
 }: {
   pairedDevices: PairedDevice[];
+  profileName: string;
+  profileNameInput: string;
+  onProfileNameInputChange: (value: string) => void;
+  onSaveProfileName: () => void;
+  isSavingProfileName: boolean;
   syncPairCode: string | null;
   syncStatus: "idle" | "connecting" | "connected" | "error";
   syncError: string | null;
@@ -1025,88 +1178,175 @@ const DevicesPanel = ({
   isPairing: boolean;
   onPairDevice: () => void;
   onRemoveDevice: (deviceId: string) => void;
+  onRenameDevice: (deviceId: string, name: string) => void;
+  renamingDeviceId: string | null;
   currentDeviceId: string | null;
   mobile?: boolean;
-}) => (
-  <Card className="surface-card rounded-[30px] p-5">
-    <div className="mb-4">
-      <h3 className="text-xl font-semibold text-[var(--text-primary)]">已配對裝置</h3>
-      <p className="mt-1 text-sm text-[var(--text-secondary)]">
-        使用配對碼連接不同裝置，讓收藏、歷史、Mix 和歌單一起同步。
-      </p>
-    </div>
-    <div className="mb-5 grid gap-3">
-      <div className="surface-subtle min-w-0 rounded-[24px] border px-4 py-4">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
-          配對碼
+}) => {
+  const [editingDeviceId, setEditingDeviceId] = useState<string | null>(null);
+  const [deviceNameInput, setDeviceNameInput] = useState("");
+
+  return (
+    <Card className="surface-card rounded-[30px] p-5">
+      <div className="mb-4">
+        <h3 className="text-xl font-semibold text-[var(--text-primary)]">已配對裝置</h3>
+        <p className="mt-1 text-sm text-[var(--text-secondary)]">
+          使用配對碼連接不同裝置，讓收藏、歷史、Mix 和歌單一起同步。
         </p>
-        <p className="mt-2 text-2xl font-semibold tracking-[0.28em] text-[var(--text-primary)]">
-          {syncPairCode ?? "------"}
-        </p>
-        <p className="mt-2 text-sm text-[var(--text-secondary)]">
-          {syncStatus === "connected"
-            ? "目前同步已連線，其他裝置輸入這組代碼即可加入。"
-            : syncStatus === "connecting"
-              ? "正在建立同步連線..."
-              : "同步尚未就緒，系統會自動重試。"}
-        </p>
-        {syncError ? <p className="mt-2 text-sm text-red-500">{syncError}</p> : null}
       </div>
-      <div className="min-w-0 grid gap-3">
-        <input
-          value={pairCodeInput}
-          onChange={(event) => onPairCodeInputChange(event.target.value.toUpperCase())}
-          placeholder="輸入配對碼"
-          className="h-12 w-full min-w-0 rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] px-4 text-sm tracking-[0.22em] text-[var(--text-primary)] uppercase outline-none"
-        />
-        <Button
-          className="h-12 w-full rounded-2xl px-5"
-          disabled={isPairing || pairCodeInput.trim().length < 6}
-          onClick={onPairDevice}
-        >
-          連接裝置
-        </Button>
-      </div>
-    </div>
-    <ScrollArea className="w-full" maxHeight={mobile ? "28vh" : "30vh"}>
-      <div className="grid gap-3">
-        {pairedDevices.map((device) => (
-          <div
-            key={device.id}
-            className="surface-subtle flex items-center justify-between gap-4 rounded-[24px] border px-4 py-4"
-          >
-            <div className="min-w-0">
-              <p className="text-base font-semibold text-[var(--text-primary)]">
-                {device.name}
-              </p>
-              <p className="mt-1 truncate text-sm text-[var(--text-secondary)]">
-                {device.kind === "desktop" ? "桌面裝置" : "手機裝置"} ·{" "}
-                {device.connected ? "已連線" : "離線"}
-                {device.lastSeenAt ? ` · ${new Date(device.lastSeenAt).toLocaleString()}` : ""}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              {device.id === currentDeviceId ? (
-                <span className="rounded-full border border-[color:var(--dynamic-ring)] bg-[var(--accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--accent)]">
-                  本機
-                </span>
-              ) : null}
-              {!device.isCurrentDevice ? (
-                <Button
-                  variant="outline"
-                  className="rounded-2xl"
-                  onClick={() => onRemoveDevice(device.id)}
-                >
-                  移除
-                </Button>
-              ) : null}
-            </div>
+      <div className="mb-5 grid gap-3">
+        <div className="surface-subtle min-w-0 rounded-[24px] border px-4 py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+            使用者名稱
+          </p>
+          <p className="mt-2 text-sm text-[var(--text-secondary)]">
+            這個名稱會用在多裝置同步與點歌者顯示。
+          </p>
+          <div className="mt-3 flex gap-2">
+            <input
+              value={profileNameInput}
+              onChange={(event) => onProfileNameInputChange(event.target.value)}
+              placeholder="輸入使用者名稱"
+              className="h-11 w-full min-w-0 rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-elevated)] px-4 text-sm text-[var(--text-primary)] outline-none"
+            />
+            <Button
+              className="h-11 shrink-0 rounded-2xl px-4"
+              onClick={onSaveProfileName}
+              disabled={isSavingProfileName || profileNameInput.trim().length === 0}
+            >
+              儲存
+            </Button>
           </div>
-        ))}
+          <p className="mt-2 text-xs text-[var(--text-muted)]">目前：{profileName}</p>
+        </div>
+        <div className="surface-subtle min-w-0 rounded-[24px] border px-4 py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+            配對碼
+          </p>
+          <p className="mt-2 text-2xl font-semibold tracking-[0.28em] text-[var(--text-primary)]">
+            {syncPairCode ?? "------"}
+          </p>
+          <p className="mt-2 text-sm text-[var(--text-secondary)]">
+            {syncStatus === "connected"
+              ? "目前同步已連線，其他裝置輸入這組代碼即可加入。"
+              : syncStatus === "connecting"
+                ? "正在建立同步連線..."
+                : "同步尚未就緒，系統會自動重試。"}
+          </p>
+          {syncError ? <p className="mt-2 text-sm text-red-500">{syncError}</p> : null}
+        </div>
+        <div className="min-w-0 grid gap-3">
+          <input
+            value={pairCodeInput}
+            onChange={(event) => onPairCodeInputChange(event.target.value.toUpperCase())}
+            placeholder="輸入配對碼"
+            className="h-12 w-full min-w-0 rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] px-4 text-sm tracking-[0.22em] text-[var(--text-primary)] uppercase outline-none"
+          />
+          <Button
+            className="h-12 w-full rounded-2xl px-5"
+            disabled={isPairing || pairCodeInput.trim().length < 6}
+            onClick={onPairDevice}
+          >
+            連接裝置
+          </Button>
+        </div>
       </div>
-    </ScrollArea>
-  </Card>
-);
+      <ScrollArea className="w-full" maxHeight={mobile ? "28vh" : "30vh"}>
+        <div className="grid gap-3">
+          {pairedDevices.map((device) => {
+            const detail = formatDeviceDetail(device.metadata, device.kind);
+            const isEditing = editingDeviceId === device.id;
+
+            return (
+              <div
+                key={device.id}
+                className="surface-subtle rounded-[24px] border px-4 py-4"
+              >
+                <div className="min-w-0">
+                  {isEditing ? (
+                    <div className="flex flex-col gap-2">
+                      <input
+                        value={deviceNameInput}
+                        onChange={(event) => setDeviceNameInput(event.target.value)}
+                        placeholder="輸入裝置名稱"
+                        className="h-10 w-full min-w-0 rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-elevated)] px-3 text-sm text-[var(--text-primary)] outline-none"
+                      />
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          className="h-10 rounded-2xl px-3"
+                          disabled={
+                            renamingDeviceId === device.id || deviceNameInput.trim().length === 0
+                          }
+                          onClick={() => {
+                            onRenameDevice(device.id, deviceNameInput);
+                            setEditingDeviceId(null);
+                            setDeviceNameInput("");
+                          }}
+                        >
+                          儲存
+                        </Button>
+                        <Button
+                          variant="outline"
+                          className="h-10 rounded-2xl px-3"
+                          onClick={() => {
+                            setEditingDeviceId(null);
+                            setDeviceNameInput("");
+                          }}
+                        >
+                          取消
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <p className="text-base font-semibold text-[var(--text-primary)]">
+                        {device.displayName}
+                      </p>
+                      <p className="mt-1 break-words text-sm text-[var(--text-secondary)]">
+                        {detail} · {device.connected ? "已連線" : "離線"}
+                        {device.lastSeenAt
+                          ? ` · ${new Date(device.lastSeenAt).toLocaleString()}`
+                          : ""}
+                      </p>
+                    </>
+                  )}
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  {device.id === currentDeviceId ? (
+                    <span className="rounded-full border border-[color:var(--dynamic-ring)] bg-[var(--accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--accent)]">
+                      本機
+                    </span>
+                  ) : null}
+                  {!isEditing ? (
+                    <Button
+                      variant="outline"
+                      className="rounded-2xl"
+                      onClick={() => {
+                        setEditingDeviceId(device.id);
+                        setDeviceNameInput(device.customName ?? device.displayName);
+                      }}
+                    >
+                      重新命名
+                    </Button>
+                  ) : null}
+                  {!device.isCurrentDevice ? (
+                    <Button
+                      variant="outline"
+                      className="rounded-2xl"
+                      onClick={() => onRemoveDevice(device.id)}
+                    >
+                      移除
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+    </Card>
+  );
+};
 
 function getSectionSearchPlaceholder(section: LibrarySection) {
   if (section === "playlists") {

--- a/frontend/src/components/mobile/MobileContent.tsx
+++ b/frontend/src/components/mobile/MobileContent.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/components/ui/toast";
 import { usePlayerStore } from "@/stores/playerStore";
-import { useLibraryStore } from "@/stores/libraryStore";
+import { getCurrentRequester, useLibraryStore } from "@/stores/libraryStore";
 import { api } from "@/services/api";
 import { formatTime } from "@/utils/format";
 import type { Track } from "@/types";
@@ -25,6 +25,9 @@ export const MobileContent = () => {
   const setSearchResults = usePlayerStore((state) => state.setSearchResults);
   const openPlaylistPicker = useLibraryStore((state) => state.openPlaylistPicker);
   const saveMix = useLibraryStore((state) => state.saveMix);
+  const currentRequester = useLibraryStore((state) =>
+    getCurrentRequester(state.snapshot),
+  );
   const { showToast } = useToast();
 
   const handleSearch = async (e: React.FormEvent) => {
@@ -52,7 +55,7 @@ export const MobileContent = () => {
   const handleAddToQueue = async (track: Track) => {
     setAddingId(track.videoId);
     try {
-      const response = await api.addToQueue(track);
+      const response = await api.addToQueue(track, currentRequester);
       if (response.success) {
         showToast({ message: "已加入播放佇列", type: "success" });
       } else {
@@ -68,7 +71,7 @@ export const MobileContent = () => {
   const handleCreateMix = async (track: Track) => {
     setCreatingMixId(track.videoId);
     try {
-      const response = await api.createMix(track);
+      const response = await api.createMix(track, currentRequester);
       if (response.success && response.data) {
         void saveMix(track, response.data.tracks);
         showToast({

--- a/frontend/src/components/mobile/MobileNowPlayingSheet.tsx
+++ b/frontend/src/components/mobile/MobileNowPlayingSheet.tsx
@@ -38,6 +38,7 @@ export const MobileNowPlayingSheet = () => {
   const isFavorite = currentTrack
     ? favorites.some((favorite) => favorite.videoId === currentTrack.videoId)
     : false;
+  const requesterLabel = currentTrack?.requestedBy?.profileName?.trim() || null;
 
   const handleFavorite = async () => {
     if (!currentTrack || !libraryReady) {
@@ -138,6 +139,14 @@ export const MobileNowPlayingSheet = () => {
                       >
                         {currentTrack.artist}
                       </p>
+                      {requesterLabel ? (
+                        <p
+                          className="line-clamp-1 text-sm text-[var(--text-muted)]"
+                          title={`點歌者：${requesterLabel}`}
+                        >
+                          點歌者：{requesterLabel}
+                        </p>
+                      ) : null}
                     </div>
                   </div>
                 </div>
@@ -206,6 +215,14 @@ export const MobileNowPlayingSheet = () => {
                   >
                     {currentTrack.artist}
                   </p>
+                  {requesterLabel ? (
+                    <p
+                      className="truncate text-xs text-[var(--text-muted)]"
+                      title={`點歌者：${requesterLabel}`}
+                    >
+                      點歌者：{requesterLabel}
+                    </p>
+                  ) : null}
                 </div>
               </div>
 

--- a/frontend/src/components/player/MiniPlayer.tsx
+++ b/frontend/src/components/player/MiniPlayer.tsx
@@ -95,6 +95,14 @@ export const MiniPlayer = () => {
                 >
                   {currentTrack.artist}
                 </p>
+                {currentTrack.requestedBy?.profileName?.trim() ? (
+                  <p
+                    className="truncate text-[11px] text-[var(--text-muted)]"
+                    title={`點歌者：${currentTrack.requestedBy.profileName}`}
+                  >
+                    點歌者：{currentTrack.requestedBy.profileName}
+                  </p>
+                ) : null}
               </div>
 
               <RadioToggleButton indicatorOnly className="hidden sm:inline-flex" />

--- a/frontend/src/components/player/NowPlaying.tsx
+++ b/frontend/src/components/player/NowPlaying.tsx
@@ -161,6 +161,7 @@ export const NowPlaying = ({
     (favorite) => favorite.videoId === currentTrack.videoId,
   );
   const isSidebarCompact = compact && sidebarMode;
+  const requesterLabel = currentTrack.requestedBy?.profileName?.trim() || null;
 
   return (
     <div
@@ -224,6 +225,21 @@ export const NowPlaying = ({
           >
             {currentTrack.artist}
           </p>
+          {requesterLabel ? (
+            <p
+              className={cn(
+                "truncate text-[var(--text-muted)]",
+                isSidebarCompact
+                  ? "text-sm"
+                  : compact
+                    ? "text-base"
+                    : "text-sm lg:text-base",
+              )}
+              title={`點歌者：${requesterLabel}`}
+            >
+              點歌者：{requesterLabel}
+            </p>
+          ) : null}
         </div>
         <div
           className={cn(

--- a/frontend/src/components/player/PlayerSection.tsx
+++ b/frontend/src/components/player/PlayerSection.tsx
@@ -142,6 +142,14 @@ export const PlayerSection = ({
                         >
                           {nextTrack.artist}
                         </p>
+                        {nextTrack.requestedBy?.profileName?.trim() ? (
+                          <p
+                            className="truncate text-xs text-[var(--text-muted)]"
+                            title={`點歌者：${nextTrack.requestedBy.profileName}`}
+                          >
+                            點歌者：{nextTrack.requestedBy.profileName}
+                          </p>
+                        ) : null}
                       </div>
                       <span className="shrink-0 rounded-full border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--text-primary)]">
                         {formatTime(nextTrack.duration)}

--- a/frontend/src/components/queue/QueueItem.tsx
+++ b/frontend/src/components/queue/QueueItem.tsx
@@ -51,6 +51,8 @@ export const QueueItem = ({
   onTouchEnd,
   onTouchCancel,
 }: QueueItemProps) => {
+  const requesterLabel = track.requestedBy?.profileName?.trim() || null;
+
   return (
     <div
       data-queue-item-index={index}
@@ -167,6 +169,17 @@ export const QueueItem = ({
           >
             {track.artist} • {formatTime(track.duration)}
           </p>
+          {requesterLabel ? (
+            <p
+              className={cn(
+                "mt-1 truncate text-[var(--text-muted)]",
+                mobile ? "text-xs leading-5" : "text-[11px]",
+              )}
+              title={`點歌者：${requesterLabel}`}
+            >
+              點歌者：{requesterLabel}
+            </p>
+          ) : null}
         </div>
         <div
           className={cn(

--- a/frontend/src/components/search/MobileSearchPage.tsx
+++ b/frontend/src/components/search/MobileSearchPage.tsx
@@ -9,6 +9,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/components/ui/toast";
 import { usePlayerStore } from "@/stores/playerStore";
+import { getCurrentRequester, useLibraryStore } from "@/stores/libraryStore";
 import { api } from "@/services/api";
 import { formatTime } from "@/utils/format";
 import type { Track } from "@/types";
@@ -28,6 +29,9 @@ export const MobileSearchPage = () => {
   );
   const searchResults = usePlayerStore((state) => state.searchResults);
   const setSearchResults = usePlayerStore((state) => state.setSearchResults);
+  const currentRequester = useLibraryStore((state) =>
+    getCurrentRequester(state.snapshot),
+  );
   const { showToast } = useToast();
 
   // 自動聚焦輸入框
@@ -80,7 +84,7 @@ export const MobileSearchPage = () => {
       .setLoadingTrack(true, `正在載入「${track.title}」...`);
 
     try {
-      const response = await api.addToQueue(track);
+      const response = await api.addToQueue(track, currentRequester);
       if (response.success) {
         showToast({ message: "已加入播放佇列", type: "success" });
       } else {

--- a/frontend/src/components/search/SearchModal.tsx
+++ b/frontend/src/components/search/SearchModal.tsx
@@ -12,7 +12,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/components/ui/toast";
 import { usePlayerStore } from "@/stores/playerStore";
-import { useLibraryStore } from "@/stores/libraryStore";
+import { getCurrentRequester, useLibraryStore } from "@/stores/libraryStore";
 import { api } from "@/services/api";
 import type { Track } from "@/types";
 import { X } from "lucide-react";
@@ -31,6 +31,9 @@ export const SearchModal = ({ open, onOpenChange }: SearchModalProps) => {
   const setSearchResults = usePlayerStore((state) => state.setSearchResults);
   const openPlaylistPicker = useLibraryStore((state) => state.openPlaylistPicker);
   const saveMix = useLibraryStore((state) => state.saveMix);
+  const currentRequester = useLibraryStore((state) =>
+    getCurrentRequester(state.snapshot),
+  );
   const { showToast } = useToast();
 
   const handleSearch = async (query: string) => {
@@ -61,7 +64,7 @@ export const SearchModal = ({ open, onOpenChange }: SearchModalProps) => {
       .setLoadingTrack(true, `正在載入「${track.title}」...`);
 
     try {
-      const response = await api.addToQueue(track);
+      const response = await api.addToQueue(track, currentRequester);
       if (response.success) {
         showToast({ message: "已加入播放佇列", type: "success" });
         // 保持 Modal 開啟，不調用 onOpenChange(false)
@@ -85,7 +88,7 @@ export const SearchModal = ({ open, onOpenChange }: SearchModalProps) => {
     usePlayerStore.getState().setLoadingTrack(true, "正在取得推薦歌曲...");
 
     try {
-      const response = await api.createMix(track);
+      const response = await api.createMix(track, currentRequester);
       if (response.success && response.data) {
         void saveMix(track, response.data.tracks);
         showToast({

--- a/frontend/src/components/search/SearchSection.tsx
+++ b/frontend/src/components/search/SearchSection.tsx
@@ -5,7 +5,7 @@ import { Empty } from "@/components/ui/empty";
 import { Spinner } from "@/components/ui/spinner";
 import { useToast } from "@/components/ui/toast";
 import { usePlayerStore } from "@/stores/playerStore";
-import { useLibraryStore } from "@/stores/libraryStore";
+import { getCurrentRequester, useLibraryStore } from "@/stores/libraryStore";
 import { api } from "@/services/api";
 import type { Track } from "@/types";
 
@@ -18,6 +18,9 @@ export const SearchSection = () => {
   const setSearchResults = usePlayerStore((state) => state.setSearchResults);
   const openPlaylistPicker = useLibraryStore((state) => state.openPlaylistPicker);
   const saveMix = useLibraryStore((state) => state.saveMix);
+  const currentRequester = useLibraryStore((state) =>
+    getCurrentRequester(state.snapshot),
+  );
   const { showToast } = useToast();
 
   const handleSearch = async (query: string) => {
@@ -42,7 +45,7 @@ export const SearchSection = () => {
   const handleAddToQueue = async (track: Track) => {
     setAddingId(track.videoId);
     try {
-      const response = await api.addToQueue(track);
+      const response = await api.addToQueue(track, currentRequester);
       if (response.success) {
         showToast({ message: "已加入播放佇列", type: "success" });
       } else {
@@ -58,7 +61,7 @@ export const SearchSection = () => {
   const handleCreateMix = async (track: Track) => {
     setCreatingMixId(track.videoId);
     try {
-      const response = await api.createMix(track);
+      const response = await api.createMix(track, currentRequester);
       if (response.success && response.data) {
         void saveMix(track, response.data.tracks);
         showToast({

--- a/frontend/src/hooks/useLibrarySync.ts
+++ b/frontend/src/hooks/useLibrarySync.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { api } from "@/services/api";
 import { useLibraryStore, getCurrentDevice } from "@/stores/libraryStore";
+import { detectDeviceInfo } from "@/utils/device-info";
 import { toSyncedLibraryPayload } from "@/utils/librarySync";
 import type { SyncSessionDevice, SyncedLibraryPayload } from "@/types/library";
 
@@ -24,6 +25,8 @@ export function useLibrarySync(): void {
   const setSyncStatus = useLibraryStore((state) => state.setSyncStatus);
   const applySyncSession = useLibraryStore((state) => state.applySyncSession);
   const updatePairedDevices = useLibraryStore((state) => state.updatePairedDevices);
+  const updateProfileName = useLibraryStore((state) => state.updateProfileName);
+  const refreshCurrentDevice = useLibraryStore((state) => state.refreshCurrentDevice);
   const mergeRemoteSnapshot = useLibraryStore((state) => state.mergeRemoteSnapshot);
   const removeSyncSession = useLibraryStore((state) => state.removeSyncSession);
 
@@ -37,9 +40,8 @@ export function useLibrarySync(): void {
 
   const currentDevice = getCurrentDevice(snapshot);
   const currentDeviceId = currentDevice?.id ?? null;
-  const currentDeviceName = currentDevice?.name ?? null;
-  const currentDeviceKind = currentDevice?.kind ?? null;
   const snapshotProfileId = snapshot?.profileId ?? "";
+  const snapshotProfileName = snapshot?.profileName ?? "未命名使用者";
   const snapshotSessionId = snapshot?.syncSessionId ?? null;
   const snapshotDeviceToken = snapshot?.syncDeviceToken ?? null;
 
@@ -76,9 +78,7 @@ export function useLibrarySync(): void {
     if (
       !ready ||
       !snapshot ||
-      !currentDeviceId ||
-      !currentDeviceName ||
-      !currentDeviceKind
+      !currentDeviceId
     ) {
       return;
     }
@@ -87,23 +87,35 @@ export function useLibrarySync(): void {
     const deviceToken = snapshotDeviceToken;
     const profileId = snapshotProfileId;
     const deviceId = currentDeviceId;
-    const deviceName = currentDeviceName;
-    const deviceKind = currentDeviceKind;
     const recoveryKey = `${sessionId ?? "new"}:${deviceId}:${deviceToken ?? "none"}`;
 
     let cancelled = false;
 
     async function bootstrapSyncSession() {
       setSyncStatus("connecting", { error: null });
+      const runtimeDevice = await detectDeviceInfo();
+
+      if (cancelled) {
+        return;
+      }
+
+      await refreshCurrentDevice({
+        kind: runtimeDevice.kind,
+        reportedName: runtimeDevice.reportedName,
+        metadata: runtimeDevice.metadata,
+      });
 
       const response = await api.createSyncSession({
         sessionId,
         deviceToken,
         profileId,
+        profileName: snapshotProfileName,
         device: {
           id: deviceId,
-          name: deviceName,
-          kind: deviceKind,
+          name: runtimeDevice.legacyName,
+          kind: runtimeDevice.kind,
+          reportedName: runtimeDevice.reportedName,
+          metadata: runtimeDevice.metadata,
         },
       });
 
@@ -137,6 +149,9 @@ export function useLibrarySync(): void {
       await applySyncSession({
         ...response.data,
         pairCode: response.data.pairCode,
+        profileName:
+          String((response.data as { profileName?: unknown }).profileName ?? "").trim() ||
+          snapshotProfileName,
       });
     }
 
@@ -148,11 +163,11 @@ export function useLibrarySync(): void {
   }, [
     applySyncSession,
     currentDeviceId,
-    currentDeviceKind,
-    currentDeviceName,
     ready,
+    refreshCurrentDevice,
     removeSyncSession,
     setSyncStatus,
+    snapshotProfileName,
     snapshot?.profileId,
     snapshot?.syncDeviceToken,
     snapshot?.syncSessionId,
@@ -163,9 +178,7 @@ export function useLibrarySync(): void {
       !ready ||
       !snapshotSessionId ||
       !snapshotDeviceToken ||
-      !currentDeviceId ||
-      !currentDeviceName ||
-      !currentDeviceKind
+      !currentDeviceId
     ) {
       return;
     }
@@ -177,16 +190,36 @@ export function useLibrarySync(): void {
 
     ws.onopen = () => {
       reconnectAttemptsRef.current = 0;
-      ws.send(
-        JSON.stringify({
-          type: "sync_register",
-          sessionId: snapshotSessionId,
-          deviceId: currentDeviceId,
-          deviceName: currentDeviceName,
-          deviceKind: currentDeviceKind,
-          deviceToken: snapshotDeviceToken,
-        }),
-      );
+
+      void (async () => {
+        const runtimeDevice = await detectDeviceInfo();
+        if (closedIntentionally || ws.readyState !== WebSocket.OPEN) {
+          return;
+        }
+
+        await refreshCurrentDevice({
+          kind: runtimeDevice.kind,
+          reportedName: runtimeDevice.reportedName,
+          metadata: runtimeDevice.metadata,
+        });
+
+        if (closedIntentionally || ws.readyState !== WebSocket.OPEN) {
+          return;
+        }
+
+        ws.send(
+          JSON.stringify({
+            type: "sync_register",
+            sessionId: snapshotSessionId,
+            deviceId: currentDeviceId,
+            deviceName: runtimeDevice.legacyName,
+            deviceKind: runtimeDevice.kind,
+            deviceToken: snapshotDeviceToken,
+            reportedName: runtimeDevice.reportedName,
+            deviceMetadata: runtimeDevice.metadata,
+          }),
+        );
+      })();
     };
 
     ws.onmessage = (event) => {
@@ -200,6 +233,9 @@ export function useLibrarySync(): void {
               sessionId: String(message.sessionId ?? ""),
               pairCode: String(message.pairCode ?? ""),
               profileId: String(message.profileId ?? snapshotProfileId ?? ""),
+              profileName:
+                String(message.profileName ?? snapshotProfileName ?? "").trim() ||
+                "未命名使用者",
               deviceToken: String(
                 message.deviceToken ?? snapshotDeviceToken ?? "",
               ),
@@ -237,6 +273,13 @@ export function useLibrarySync(): void {
                 error: "此裝置已被移出同步 session，請重新配對",
               });
             });
+            break;
+
+          case "sync_profile_updated":
+            void updateProfileName(
+              String(message.profileName ?? snapshotProfileName ?? "").trim() ||
+                "未命名使用者",
+            );
             break;
 
           case "sync_error":
@@ -296,16 +339,17 @@ export function useLibrarySync(): void {
   }, [
     applySyncSession,
     currentDeviceId,
-    currentDeviceKind,
-    currentDeviceName,
     mergeRemoteSnapshot,
     ready,
+    refreshCurrentDevice,
     removeSyncSession,
     setSyncStatus,
     snapshotDeviceToken,
     snapshotProfileId,
+    snapshotProfileName,
     snapshotSessionId,
     socketAttempt,
+    updateProfileName,
     updatePairedDevices,
   ]);
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -36,12 +36,25 @@ export const useWebSocket = () => {
             message.state.currentTrack === null &&
             message.state.queue.length > 0 &&
             previousState.currentTrack !== null;
+          const queueHead = message.state.queue[0] ?? null;
+          const mergedPreservedTrack =
+            shouldPreserveCurrentTrack &&
+            queueHead &&
+            previousState.currentTrack &&
+            queueHead.videoId === previousState.currentTrack.videoId
+              ? {
+                  ...previousState.currentTrack,
+                  requestedBy:
+                    queueHead.requestedBy ??
+                    previousState.currentTrack.requestedBy,
+                }
+              : previousState.currentTrack;
 
           setPlaybackState(
             shouldPreserveCurrentTrack
               ? {
                   ...message.state,
-                  currentTrack: previousState.currentTrack,
+                  currentTrack: mergedPreservedTrack,
                   position:
                     message.state.position > 0
                       ? message.state.position

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,10 @@
 import type { ApiResponse, Track } from "@/types";
-import type { SyncSessionResponse } from "@/types/library";
+import type {
+  SyncDeviceMetadata,
+  SyncProfileResponse,
+  SyncSessionDevice,
+  SyncSessionResponse,
+} from "@/types/library";
 
 export interface SystemInfoResponse {
   appVersion: string;
@@ -9,6 +14,16 @@ export interface SystemInfoResponse {
 }
 
 const API_BASE = "/api";
+
+type RequestedByPayload = Track["requestedBy"];
+
+type SyncDevicePayload = {
+  id: string;
+  name?: string | null;
+  reportedName?: string | null;
+  kind: "desktop" | "mobile";
+  metadata?: SyncDeviceMetadata | null;
+};
 
 class ApiService {
   private async request<T>(
@@ -61,20 +76,24 @@ class ApiService {
   }
 
   // 加入到佇列
-  async addToQueue(track: Track): Promise<ApiResponse<void>> {
-    return this.request<void>("/queue", {
+  async addToQueue(
+    track: Track,
+    requestedBy?: RequestedByPayload,
+  ): Promise<ApiResponse<{ message: string }>> {
+    return this.request<{ message: string }>("/queue", {
       method: "POST",
-      body: JSON.stringify({ track }),
+      body: JSON.stringify({ track, requestedBy }),
     });
   }
 
   // 創建 Mix 混合播放清單
   async createMix(
     track: Track,
+    requestedBy?: RequestedByPayload,
   ): Promise<ApiResponse<{ count: number; tracks: Track[] }>> {
     return this.request<{ count: number; tracks: Track[] }>("/mix", {
       method: "POST",
-      body: JSON.stringify({ track }),
+      body: JSON.stringify({ track, requestedBy }),
     });
   }
 
@@ -140,32 +159,37 @@ class ApiService {
   async playPlaylist(
     playlistId: string,
     tracks: Track[],
-  ): Promise<ApiResponse<void>> {
-    return this.request<void>(`/library/playlists/${playlistId}/play`, {
-      method: "POST",
-      body: JSON.stringify({ tracks }),
-    });
+    requestedBy?: RequestedByPayload,
+  ): Promise<ApiResponse<{ message: string }>> {
+    return this.request<{ message: string }>(
+      `/library/playlists/${playlistId}/play`,
+      {
+        method: "POST",
+        body: JSON.stringify({ tracks, requestedBy }),
+      },
+    );
   }
 
   async queuePlaylist(
     playlistId: string,
     tracks: Track[],
-  ): Promise<ApiResponse<void>> {
-    return this.request<void>(`/library/playlists/${playlistId}/queue`, {
-      method: "POST",
-      body: JSON.stringify({ tracks }),
-    });
+    requestedBy?: RequestedByPayload,
+  ): Promise<ApiResponse<{ message: string }>> {
+    return this.request<{ message: string }>(
+      `/library/playlists/${playlistId}/queue`,
+      {
+        method: "POST",
+        body: JSON.stringify({ tracks, requestedBy }),
+      },
+    );
   }
 
   async createSyncSession(payload: {
     sessionId?: string | null;
     deviceToken?: string | null;
     profileId: string;
-    device: {
-      id: string;
-      name: string;
-      kind: "desktop" | "mobile";
-    };
+    profileName?: string | null;
+    device: SyncDevicePayload;
   }): Promise<ApiResponse<SyncSessionResponse>> {
     return this.request<SyncSessionResponse>("/sync/session", {
       method: "POST",
@@ -176,11 +200,7 @@ class ApiService {
   async pairSyncSession(payload: {
     pairCode: string;
     profileId: string;
-    device: {
-      id: string;
-      name: string;
-      kind: "desktop" | "mobile";
-    };
+    device: SyncDevicePayload;
   }): Promise<ApiResponse<SyncSessionResponse>> {
     return this.request<SyncSessionResponse>("/sync/pair", {
       method: "POST",
@@ -193,6 +213,30 @@ class ApiService {
   ): Promise<ApiResponse<{ devices: SyncSessionResponse["devices"] }>> {
     return this.request<{ devices: SyncSessionResponse["devices"] }>(
       `/sync/devices?sessionId=${encodeURIComponent(sessionId)}`,
+    );
+  }
+
+  async updateSyncProfileName(
+    sessionId: string,
+    profileName: string,
+  ): Promise<ApiResponse<SyncProfileResponse>> {
+    return this.request<SyncProfileResponse>("/sync/session/profile", {
+      method: "PATCH",
+      body: JSON.stringify({ sessionId, profileName }),
+    });
+  }
+
+  async renameSyncDevice(
+    sessionId: string,
+    deviceId: string,
+    name: string,
+  ): Promise<ApiResponse<{ devices: SyncSessionDevice[] }>> {
+    return this.request<{ devices: SyncSessionDevice[] }>(
+      `/sync/devices/${encodeURIComponent(deviceId)}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ sessionId, name }),
+      },
     );
   }
 

--- a/frontend/src/services/library-db.ts
+++ b/frontend/src/services/library-db.ts
@@ -1,9 +1,15 @@
-import type { LibrarySnapshot, PairedDevice } from "@/types/library";
+import { detectDeviceInfoSync } from "@/utils/device-info";
+import type {
+  LibrarySnapshot,
+  PairedDevice,
+  SyncDeviceMetadata,
+} from "@/types/library";
 
 const DATABASE_NAME = "youtube-music-bot-library";
 const DATABASE_VERSION = 1;
 const STORE_NAME = "snapshots";
 const SNAPSHOT_KEY = "primary";
+const DEFAULT_PROFILE_NAME = "未命名使用者";
 
 function openDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -35,16 +41,12 @@ export async function loadLibrarySnapshot(): Promise<LibrarySnapshot> {
   const database = await openDatabase();
   const transaction = database.transaction(STORE_NAME, "readonly");
   const store = transaction.objectStore(STORE_NAME);
-  const snapshot = await requestToPromise(store.get(SNAPSHOT_KEY));
+  const rawSnapshot = await requestToPromise(store.get(SNAPSHOT_KEY));
 
   database.close();
 
-  if (snapshot) {
-    return {
-      ...(snapshot as LibrarySnapshot),
-      syncDeviceToken:
-        (snapshot as Partial<LibrarySnapshot>).syncDeviceToken ?? null,
-    };
+  if (rawSnapshot) {
+    return normalizeSnapshot(rawSnapshot as Partial<LibrarySnapshot>);
   }
 
   const initialSnapshot = createInitialLibrarySnapshot();
@@ -73,14 +75,18 @@ export async function saveLibrarySnapshot(
 }
 
 export function createInitialLibrarySnapshot(): LibrarySnapshot {
+  const detected = detectDeviceInfoSync();
   const deviceId = crypto.randomUUID();
   const profileId = crypto.randomUUID();
   const now = new Date().toISOString();
-  const kind = window.innerWidth >= 1024 ? "desktop" : "mobile";
   const currentDevice: PairedDevice = {
     id: deviceId,
-    name: inferDeviceName(kind),
-    kind,
+    name: detected.reportedName,
+    reportedName: detected.reportedName,
+    customName: null,
+    displayName: detected.reportedName,
+    kind: detected.kind,
+    metadata: detected.metadata,
     pairedAt: now,
     isCurrentDevice: true,
     status: "available",
@@ -88,6 +94,7 @@ export function createInitialLibrarySnapshot(): LibrarySnapshot {
 
   return {
     profileId,
+    profileName: DEFAULT_PROFILE_NAME,
     deviceId,
     updatedAt: now,
     syncSessionId: null,
@@ -100,7 +107,144 @@ export function createInitialLibrarySnapshot(): LibrarySnapshot {
   };
 }
 
-function inferDeviceName(kind: "desktop" | "mobile"): string {
-  const platform = navigator.platform || "Unknown device";
-  return kind === "desktop" ? `Desktop · ${platform}` : `Mobile · ${platform}`;
+function normalizeMetadata(raw: unknown): SyncDeviceMetadata | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+
+  const value = raw as Partial<SyncDeviceMetadata>;
+  const asNullableString = (field: unknown): string | null =>
+    typeof field === "string" && field.trim().length > 0 ? field : null;
+
+  return {
+    platformFamily: asNullableString(value.platformFamily),
+    platformVersion: asNullableString(value.platformVersion),
+    architecture: asNullableString(value.architecture),
+    browserName: asNullableString(value.browserName),
+    browserVersion: asNullableString(value.browserVersion),
+    model: asNullableString(value.model),
+  };
+}
+
+function normalizePairedDevice(
+  raw: unknown,
+  currentDeviceId: string,
+  fallback: PairedDevice,
+): PairedDevice {
+  if (!raw || typeof raw !== "object") {
+    return fallback;
+  }
+
+  const source = raw as Partial<PairedDevice>;
+  const id = typeof source.id === "string" && source.id.trim() ? source.id : fallback.id;
+  const kind = source.kind === "mobile" ? "mobile" : "desktop";
+  const metadata = normalizeMetadata(source.metadata);
+  const legacyName =
+    typeof source.name === "string" && source.name.trim().length > 0
+      ? source.name
+      : null;
+  const reportedName =
+    typeof source.reportedName === "string" && source.reportedName.trim().length > 0
+      ? source.reportedName
+      : legacyName ?? fallback.reportedName;
+  const customName =
+    typeof source.customName === "string" && source.customName.trim().length > 0
+      ? source.customName
+      : null;
+  const displayName =
+    typeof source.displayName === "string" && source.displayName.trim().length > 0
+      ? source.displayName
+      : customName ?? reportedName;
+
+  return {
+    id,
+    name: displayName,
+    reportedName,
+    customName,
+    displayName,
+    kind,
+    metadata: metadata ?? fallback.metadata,
+    pairedAt:
+      typeof source.pairedAt === "string" && source.pairedAt.trim().length > 0
+        ? source.pairedAt
+        : fallback.pairedAt,
+    isCurrentDevice:
+      typeof source.isCurrentDevice === "boolean"
+        ? source.isCurrentDevice
+        : id === currentDeviceId,
+    status: source.status === "coming_soon" ? "coming_soon" : "available",
+    connected: source.connected,
+    lastSeenAt:
+      typeof source.lastSeenAt === "string" && source.lastSeenAt.trim().length > 0
+        ? source.lastSeenAt
+        : undefined,
+  };
+}
+
+function normalizeSnapshot(raw: Partial<LibrarySnapshot>): LibrarySnapshot {
+  const fallbackSnapshot = createInitialLibrarySnapshot();
+  const deviceId =
+    typeof raw.deviceId === "string" && raw.deviceId.trim().length > 0
+      ? raw.deviceId
+      : fallbackSnapshot.deviceId;
+  const now = new Date().toISOString();
+  const detected = detectDeviceInfoSync();
+  const fallbackCurrentDevice: PairedDevice = {
+    id: deviceId,
+    name: detected.reportedName,
+    reportedName: detected.reportedName,
+    customName: null,
+    displayName: detected.reportedName,
+    kind: detected.kind,
+    metadata: detected.metadata,
+    pairedAt: now,
+    isCurrentDevice: true,
+    status: "available",
+  };
+
+  const rawDevices = Array.isArray(raw.pairedDevices) ? raw.pairedDevices : [];
+  const normalizedDevices =
+    rawDevices.length > 0
+      ? rawDevices.map((device) =>
+          normalizePairedDevice(device, deviceId, fallbackCurrentDevice),
+        )
+      : [fallbackCurrentDevice];
+
+  if (!normalizedDevices.some((device) => device.isCurrentDevice)) {
+    const deviceIndex = normalizedDevices.findIndex((device) => device.id === deviceId);
+    if (deviceIndex >= 0) {
+      normalizedDevices[deviceIndex] = {
+        ...normalizedDevices[deviceIndex],
+        isCurrentDevice: true,
+      };
+    } else {
+      normalizedDevices.unshift(fallbackCurrentDevice);
+    }
+  }
+
+  return {
+    profileId:
+      typeof raw.profileId === "string" && raw.profileId.trim().length > 0
+        ? raw.profileId
+        : fallbackSnapshot.profileId,
+    profileName:
+      typeof raw.profileName === "string" && raw.profileName.trim().length > 0
+        ? raw.profileName
+        : DEFAULT_PROFILE_NAME,
+    deviceId,
+    updatedAt:
+      typeof raw.updatedAt === "string" && raw.updatedAt.trim().length > 0
+        ? raw.updatedAt
+        : now,
+    syncSessionId: raw.syncSessionId ?? null,
+    syncDeviceToken: raw.syncDeviceToken ?? null,
+    favorites: raw.favorites ?? [],
+    history: raw.history ?? [],
+    savedMixes: raw.savedMixes ?? [],
+    playlists: raw.playlists ?? [],
+    removedFavorites: raw.removedFavorites ?? [],
+    deletedPlaylists: raw.deletedPlaylists ?? [],
+    deletedSavedMixes: raw.deletedSavedMixes ?? [],
+    pairedDevices: normalizedDevices,
+  };
 }

--- a/frontend/src/stores/libraryStore.ts
+++ b/frontend/src/stores/libraryStore.ts
@@ -8,6 +8,8 @@ import type {
   Playlist,
   PlaylistTrackEntry,
   SavedMix,
+  SyncDeviceKind,
+  SyncDeviceMetadata,
   SyncSessionDevice,
   SyncedLibraryPayload,
 } from "@/types/library";
@@ -20,6 +22,7 @@ import {
   mergeLibraryPayload,
   mergePairedDevices,
 } from "@/utils/librarySync";
+import { getCurrentRequester } from "@/utils/requester";
 import { reorderItems } from "@/utils/reorder";
 
 const MAX_HISTORY_ENTRIES = 1000;
@@ -42,9 +45,16 @@ interface LibraryStore {
     options?: { pairCode?: string | null; error?: string | null },
   ) => void;
   updatePairedDevices: (devices: SyncSessionDevice[]) => Promise<void>;
+  updateProfileName: (profileName: string) => Promise<void>;
+  refreshCurrentDevice: (device: {
+    kind: SyncDeviceKind;
+    reportedName: string;
+    metadata: SyncDeviceMetadata | null;
+  }) => Promise<void>;
   applySyncSession: (session: {
     sessionId: string;
     profileId: string;
+    profileName?: string;
     devices: SyncSessionDevice[];
     deviceToken: string;
     pairCode?: string | null;
@@ -201,11 +211,46 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       { touchUpdatedAt: false },
     );
   },
+  updateProfileName: async (profileName) => {
+    await persistSnapshot(
+      (snapshot) => ({
+        ...snapshot,
+        profileName: profileName.trim() || snapshot.profileName,
+      }),
+      { touchUpdatedAt: false },
+    );
+  },
+  refreshCurrentDevice: async (device) => {
+    const reportedName = device.reportedName.trim() || "Desktop · Unknown";
+    await persistSnapshot(
+      (snapshot) => ({
+        ...snapshot,
+        pairedDevices: snapshot.pairedDevices.map((pairedDevice) => {
+          if (pairedDevice.id !== snapshot.deviceId) {
+            return pairedDevice;
+          }
+
+          const displayName = pairedDevice.customName ?? reportedName;
+
+          return {
+            ...pairedDevice,
+            name: displayName,
+            reportedName,
+            displayName,
+            kind: device.kind,
+            metadata: device.metadata,
+          };
+        }),
+      }),
+      { touchUpdatedAt: false },
+    );
+  },
   applySyncSession: async (session) => {
     await persistSnapshot(
       (snapshot) => ({
         ...snapshot,
         profileId: session.profileId,
+        profileName: session.profileName?.trim() || snapshot.profileName,
         syncSessionId: session.sessionId,
         syncDeviceToken: session.deviceToken,
         pairedDevices: mergePairedDevices(
@@ -441,3 +486,5 @@ export function getCurrentDevice(snapshot: LibrarySnapshot | null): PairedDevice
     snapshot.pairedDevices.find((device) => device.isCurrentDevice) ?? null
   );
 }
+
+export { getCurrentRequester };

--- a/frontend/src/stores/playerStore.ts
+++ b/frontend/src/stores/playerStore.ts
@@ -189,8 +189,26 @@ function areTracksEqual(left: Track | null, right: Track | null): boolean {
     left.artist === right.artist &&
     left.duration === right.duration &&
     left.thumbnail === right.thumbnail &&
+    areRequestersEqual(left.requestedBy, right.requestedBy) &&
     left.queueOrigin === right.queueOrigin &&
     left.radioGenerated === right.radioGenerated
+  );
+}
+
+function areRequestersEqual(
+  left: Track["requestedBy"] | undefined,
+  right: Track["requestedBy"] | undefined,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (!left || !right) {
+    return false;
+  }
+
+  return (
+    left.profileId === right.profileId && left.profileName === right.profileName
   );
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,10 @@
 export type QueueOrigin = "manual" | "mix" | "radio" | "playlist";
 
+export interface TrackRequester {
+  profileId: string;
+  profileName: string;
+}
+
 // 歌曲資訊
 export interface Track {
   videoId: string;
@@ -7,6 +12,7 @@ export interface Track {
   artist: string;
   duration: number; // 秒
   thumbnail?: string;
+  requestedBy?: TrackRequester;
   queueOrigin?: QueueOrigin;
   radioGenerated?: boolean;
 }

--- a/frontend/src/types/library.ts
+++ b/frontend/src/types/library.ts
@@ -1,5 +1,16 @@
 import type { Track } from "./index";
 
+export type SyncDeviceKind = "desktop" | "mobile";
+
+export interface SyncDeviceMetadata {
+  platformFamily?: string | null;
+  platformVersion?: string | null;
+  architecture?: string | null;
+  browserName?: string | null;
+  browserVersion?: string | null;
+  model?: string | null;
+}
+
 export interface FavoriteTrack {
   videoId: string;
   track: Track;
@@ -51,8 +62,12 @@ export interface DeletedPlaylist {
 
 export interface PairedDevice {
   id: string;
-  name: string;
-  kind: "desktop" | "mobile";
+  name: string; // Legacy alias of displayName for compatibility
+  reportedName: string;
+  customName: string | null;
+  displayName: string;
+  kind: SyncDeviceKind;
+  metadata: SyncDeviceMetadata | null;
   pairedAt: string;
   isCurrentDevice: boolean;
   status: "available" | "coming_soon";
@@ -62,6 +77,7 @@ export interface PairedDevice {
 
 export interface LibrarySnapshot {
   profileId: string;
+  profileName: string;
   deviceId: string;
   updatedAt: string;
   syncSessionId: string | null;
@@ -78,6 +94,7 @@ export interface LibrarySnapshot {
 
 export interface SyncedLibraryPayload {
   profileId: string;
+  profileName?: string;
   updatedAt: string;
   syncSessionId: string | null;
   favorites: FavoriteTrack[];
@@ -91,8 +108,12 @@ export interface SyncedLibraryPayload {
 
 export interface SyncSessionDevice {
   id: string;
-  name: string;
-  kind: "desktop" | "mobile";
+  name: string; // Legacy alias of displayName for compatibility
+  reportedName: string;
+  customName: string | null;
+  displayName: string;
+  kind: SyncDeviceKind;
+  metadata: SyncDeviceMetadata | null;
   connected: boolean;
   pairedAt: string;
   lastSeenAt: string;
@@ -102,6 +123,13 @@ export interface SyncSessionResponse {
   sessionId: string;
   pairCode: string;
   profileId: string;
+  profileName: string;
   deviceToken: string;
   devices: SyncSessionDevice[];
+}
+
+export interface SyncProfileResponse {
+  sessionId: string;
+  profileId: string;
+  profileName: string;
 }

--- a/frontend/src/utils/device-info.ts
+++ b/frontend/src/utils/device-info.ts
@@ -1,0 +1,262 @@
+import type { SyncDeviceKind, SyncDeviceMetadata } from "../types/library";
+
+const MOBILE_UA_PATTERN =
+  /Android|iPhone|iPad|iPod|webOS|BlackBerry|IEMobile|Opera Mini|Mobile/i;
+
+type NavigatorWithUAData = Navigator & {
+  userAgentData?: {
+    mobile?: boolean;
+    platform?: string;
+    brands?: Array<{ brand?: string; version?: string }>;
+    getHighEntropyValues?: (
+      hints: string[],
+    ) => Promise<Record<string, unknown>>;
+  };
+};
+
+export interface RuntimeDeviceInfo {
+  kind: SyncDeviceKind;
+  reportedName: string;
+  legacyName: string;
+  metadata: SyncDeviceMetadata | null;
+}
+
+function detectKind(userAgent: string, navigatorLike: NavigatorWithUAData): SyncDeviceKind {
+  if (typeof navigatorLike.userAgentData?.mobile === "boolean") {
+    return navigatorLike.userAgentData.mobile ? "mobile" : "desktop";
+  }
+
+  return MOBILE_UA_PATTERN.test(userAgent) ? "mobile" : "desktop";
+}
+
+function detectPlatformFamily(
+  userAgent: string,
+  navigatorLike: NavigatorWithUAData,
+): string {
+  const rawPlatform = navigatorLike.userAgentData?.platform ?? navigatorLike.platform ?? "";
+  const normalized = rawPlatform.toLowerCase();
+
+  if (normalized.includes("mac")) {
+    return "macOS";
+  }
+  if (normalized.includes("win")) {
+    return "Windows";
+  }
+  if (normalized.includes("linux")) {
+    return "Linux";
+  }
+  if (normalized.includes("android")) {
+    return "Android";
+  }
+  if (normalized.includes("ios") || normalized.includes("iphone") || normalized.includes("ipad")) {
+    return "iOS";
+  }
+
+  if (/Android/i.test(userAgent)) {
+    return "Android";
+  }
+  if (/(iPhone|iPad|iPod)/i.test(userAgent)) {
+    return "iOS";
+  }
+  if (/Mac OS X/i.test(userAgent)) {
+    return "macOS";
+  }
+  if (/Windows NT/i.test(userAgent)) {
+    return "Windows";
+  }
+  if (/Linux/i.test(userAgent)) {
+    return "Linux";
+  }
+
+  return rawPlatform || "Unknown";
+}
+
+function detectBrowser(userAgent: string, navigatorLike: NavigatorWithUAData): {
+  name?: string | null;
+  version?: string | null;
+} {
+  const brands = navigatorLike.userAgentData?.brands ?? [];
+  const preferredBrand = brands.find((brand) => {
+    const label = (brand.brand ?? "").toLowerCase();
+    return (
+      label.length > 0 &&
+      label !== "not a brand" &&
+      label !== "not_a brand" &&
+      label !== "chromium"
+    );
+  });
+
+  if (preferredBrand?.brand) {
+    return {
+      name: preferredBrand.brand,
+      version: preferredBrand.version ?? null,
+    };
+  }
+
+  const rules = [
+    { pattern: /(Edg|Edge)\/([\d.]+)/, name: "Edge" },
+    { pattern: /Firefox\/([\d.]+)/, name: "Firefox" },
+    { pattern: /Version\/([\d.]+).*Safari/, name: "Safari" },
+    { pattern: /Chrome\/([\d.]+)/, name: "Chrome" },
+  ];
+
+  for (const rule of rules) {
+    const match = userAgent.match(rule.pattern);
+    if (match) {
+      const versionIndex = match.length > 2 ? 2 : 1;
+      return {
+        name: rule.name,
+        version: match[versionIndex] ?? null,
+      };
+    }
+  }
+
+  return {};
+}
+
+function normalizeArchitecture(value: unknown): string | null {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (normalized === "arm" || normalized === "arm64" || normalized === "aarch64") {
+    return "ARM";
+  }
+  if (
+    normalized === "x86" ||
+    normalized === "x86_64" ||
+    normalized === "x64" ||
+    normalized === "amd64"
+  ) {
+    return "x86_64";
+  }
+
+  return value.trim();
+}
+
+function buildReportedName(kind: SyncDeviceKind, metadata: SyncDeviceMetadata | null): string {
+  const kindLabel = kind === "desktop" ? "Desktop" : "Mobile";
+  const platformFamily = metadata?.platformFamily?.trim();
+  return platformFamily ? `${kindLabel} · ${platformFamily}` : `${kindLabel} · Unknown`;
+}
+
+function createBaseMetadata(
+  userAgent: string,
+  navigatorLike: NavigatorWithUAData,
+): SyncDeviceMetadata {
+  const platformFamily = detectPlatformFamily(userAgent, navigatorLike);
+  const browser = detectBrowser(userAgent, navigatorLike);
+
+  return {
+    platformFamily,
+    browserName: browser.name ?? null,
+    browserVersion: browser.version ?? null,
+    platformVersion: null,
+    architecture: null,
+    model: null,
+  };
+}
+
+export function formatDeviceDetail(
+  metadata: SyncDeviceMetadata | null,
+  kind: SyncDeviceKind,
+): string {
+  const segments: string[] = [];
+
+  if (metadata?.platformFamily) {
+    const withVersion = metadata.platformVersion
+      ? `${metadata.platformFamily} ${metadata.platformVersion}`
+      : metadata.platformFamily;
+    segments.push(withVersion);
+  } else {
+    segments.push(kind === "desktop" ? "桌面裝置" : "手機裝置");
+  }
+
+  if (metadata?.architecture) {
+    segments.push(metadata.architecture);
+  }
+
+  if (metadata?.browserName) {
+    const browserWithVersion = metadata.browserVersion
+      ? `${metadata.browserName} ${metadata.browserVersion}`
+      : metadata.browserName;
+    segments.push(browserWithVersion);
+  }
+
+  return segments.join(" · ");
+}
+
+export function detectDeviceInfoSync(
+  navigatorLike: NavigatorWithUAData = window.navigator as NavigatorWithUAData,
+): RuntimeDeviceInfo {
+  const userAgent = navigatorLike.userAgent ?? "";
+  const kind = detectKind(userAgent, navigatorLike);
+  const metadata = createBaseMetadata(userAgent, navigatorLike);
+  const reportedName = buildReportedName(kind, metadata);
+
+  return {
+    kind,
+    reportedName,
+    legacyName: reportedName,
+    metadata,
+  };
+}
+
+export async function detectDeviceInfo(
+  navigatorLike: NavigatorWithUAData = window.navigator as NavigatorWithUAData,
+): Promise<RuntimeDeviceInfo> {
+  const base = detectDeviceInfoSync(navigatorLike);
+  const metadata: SyncDeviceMetadata = {
+    ...(base.metadata ?? {}),
+  };
+
+  try {
+    const hints = await navigatorLike.userAgentData?.getHighEntropyValues?.([
+      "architecture",
+      "bitness",
+      "model",
+      "platformVersion",
+      "uaFullVersion",
+    ]);
+
+    const architecture = normalizeArchitecture(hints?.architecture);
+    const bitness = typeof hints?.bitness === "string" ? hints.bitness : null;
+    const model = typeof hints?.model === "string" && hints.model.trim() ? hints.model : null;
+    const platformVersion =
+      typeof hints?.platformVersion === "string" && hints.platformVersion.trim()
+        ? hints.platformVersion
+        : null;
+    const uaFullVersion =
+      typeof hints?.uaFullVersion === "string" && hints.uaFullVersion.trim()
+        ? hints.uaFullVersion
+        : null;
+
+    if (architecture) {
+      metadata.architecture = bitness ? `${architecture} (${bitness}-bit)` : architecture;
+    }
+
+    if (model) {
+      metadata.model = model;
+    }
+
+    if (platformVersion) {
+      metadata.platformVersion = platformVersion;
+    }
+
+    if (uaFullVersion && metadata.browserName) {
+      metadata.browserVersion = uaFullVersion;
+    }
+  } catch {
+    // High entropy hints are optional; fallback data is already populated.
+  }
+
+  const reportedName = buildReportedName(base.kind, metadata);
+  return {
+    ...base,
+    reportedName,
+    legacyName: reportedName,
+    metadata,
+  };
+}

--- a/frontend/src/utils/librarySync.ts
+++ b/frontend/src/utils/librarySync.ts
@@ -8,6 +8,7 @@ import type {
   Playlist,
   RemovedFavorite,
   SavedMix,
+  SyncDeviceMetadata,
   SyncSessionDevice,
   SyncedLibraryPayload,
 } from "../types/library";
@@ -122,6 +123,7 @@ export function toSyncedLibraryPayload(
 ): SyncedLibraryPayload {
   return {
     profileId: snapshot.profileId,
+    profileName: snapshot.profileName,
     updatedAt: snapshot.updatedAt,
     syncSessionId: snapshot.syncSessionId,
     favorites: snapshot.favorites,
@@ -223,6 +225,11 @@ export function mergeLibraryPayload(
   return {
     ...currentSnapshot,
     profileId: currentSnapshot.profileId || incomingPayload.profileId,
+    profileName:
+      (incomingPayload.profileName &&
+      incomingPayload.profileName.trim().length > 0
+        ? incomingPayload.profileName
+        : currentSnapshot.profileName) || "未命名使用者",
     syncSessionId: incomingPayload.syncSessionId ?? currentSnapshot.syncSessionId,
     updatedAt:
       currentSnapshot.updatedAt >= incomingPayload.updatedAt
@@ -238,6 +245,25 @@ export function mergeLibraryPayload(
   };
 }
 
+function normalizeMetadata(
+  incoming: SyncDeviceMetadata | null | undefined,
+  existing: SyncDeviceMetadata | null | undefined,
+): SyncDeviceMetadata | null {
+  const candidate = incoming ?? existing;
+  if (!candidate) {
+    return null;
+  }
+
+  return {
+    platformFamily: candidate.platformFamily ?? null,
+    platformVersion: candidate.platformVersion ?? null,
+    architecture: candidate.architecture ?? null,
+    browserName: candidate.browserName ?? null,
+    browserVersion: candidate.browserVersion ?? null,
+    model: candidate.model ?? null,
+  };
+}
+
 export function mergePairedDevices(
   currentDeviceId: string,
   existingDevices: PairedDevice[],
@@ -247,11 +273,21 @@ export function mergePairedDevices(
 
   return sessionDevices.map((device) => {
     const existing = existingById.get(device.id);
+    const reportedName =
+      device.reportedName || existing?.reportedName || device.displayName || device.name;
+    const customName = device.customName ?? existing?.customName ?? null;
+    const displayName =
+      device.displayName || customName || reportedName || existing?.displayName || "Unknown";
+    const metadata = normalizeMetadata(device.metadata, existing?.metadata);
 
     return {
       id: device.id,
-      name: device.name,
+      name: displayName,
+      reportedName,
+      customName,
+      displayName,
       kind: device.kind,
+      metadata,
       pairedAt: existing?.pairedAt ?? device.pairedAt,
       isCurrentDevice: device.id === currentDeviceId,
       status: "available",

--- a/frontend/src/utils/requester.ts
+++ b/frontend/src/utils/requester.ts
@@ -1,0 +1,35 @@
+import type { Track } from "../types/index";
+import type { LibrarySnapshot } from "../types/library";
+
+const requesterCache = new WeakMap<
+  LibrarySnapshot,
+  NonNullable<Track["requestedBy"]>
+>();
+
+export function getCurrentRequester(
+  snapshot: LibrarySnapshot | null,
+): Track["requestedBy"] | undefined {
+  if (!snapshot) {
+    return undefined;
+  }
+
+  const profileId = snapshot.profileId.trim();
+  const profileName = snapshot.profileName.trim();
+
+  if (!profileId || !profileName) {
+    return undefined;
+  }
+
+  const cached = requesterCache.get(snapshot);
+  if (cached) {
+    return cached;
+  }
+
+  const requester = {
+    profileId,
+    profileName,
+  };
+
+  requesterCache.set(snapshot, requester);
+  return requester;
+}

--- a/src/__tests__/api.playlists.test.ts
+++ b/src/__tests__/api.playlists.test.ts
@@ -79,6 +79,7 @@ describe("/api/library/playlists", () => {
     const received: {
       tracks: Track[];
       origin?: QueueOrigin;
+      requestedBy?: Track["requestedBy"];
     } = {
       tracks: [],
     };
@@ -86,21 +87,32 @@ describe("/api/library/playlists", () => {
     stubMethod(
       queueService,
       "replaceQueueWithTracks",
-      (async (tracks: Track[], origin) => {
+      (async (tracks: Track[], origin, options = {}) => {
         received.tracks = tracks;
         received.origin = origin;
+        received.requestedBy = options.requestedBy;
       }) as typeof queueService.replaceQueueWithTracks,
     );
 
     const response = await api.request("/library/playlists/test-playlist/play", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tracks: playlistTracks }),
+      body: JSON.stringify({
+        tracks: playlistTracks,
+        requestedBy: {
+          profileId: "profile-a",
+          profileName: "Alice",
+        },
+      }),
     });
 
     expect(response.status).toBe(200);
     expect(received.tracks).toEqual(playlistTracks);
     expect(received.origin).toBe("playlist");
+    expect(received.requestedBy).toEqual({
+      profileId: "profile-a",
+      profileName: "Alice",
+    });
   });
 
   test("should append tracks when queueing a playlist", async () => {
@@ -108,6 +120,7 @@ describe("/api/library/playlists", () => {
     const received: {
       tracks: Track[];
       origin?: QueueOrigin;
+      requestedBy?: Track["requestedBy"];
     } = {
       tracks: [],
     };
@@ -115,21 +128,32 @@ describe("/api/library/playlists", () => {
     stubMethod(
       queueService,
       "appendTracksToQueue",
-      (async (tracks: Track[], origin) => {
+      (async (tracks: Track[], origin, options = {}) => {
         received.tracks = tracks;
         received.origin = origin;
+        received.requestedBy = options.requestedBy;
       }) as typeof queueService.appendTracksToQueue,
     );
 
     const response = await api.request("/library/playlists/test-playlist/queue", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tracks: playlistTracks }),
+      body: JSON.stringify({
+        tracks: playlistTracks,
+        requestedBy: {
+          profileId: "profile-b",
+          profileName: "Bob",
+        },
+      }),
     });
 
     expect(response.status).toBe(200);
     expect(received.tracks).toEqual(playlistTracks);
     expect(received.origin).toBe("playlist");
+    expect(received.requestedBy).toEqual({
+      profileId: "profile-b",
+      profileName: "Bob",
+    });
   });
 
   test("should surface playlist queue failures as 500 responses", async () => {

--- a/src/__tests__/api.queue.test.ts
+++ b/src/__tests__/api.queue.test.ts
@@ -34,15 +34,14 @@ function restoreMethods(): void {
   }
 }
 
-const baseTrack: Track = {
-  videoId: "base-track",
-  title: "Base Song",
-  artist: "Base Artist",
-  duration: 180,
-  thumbnail: "https://img.youtube.com/vi/base-track/mqdefault.jpg",
+const queuedTrack: Track = {
+  videoId: "queue-track",
+  title: "Queue Song",
+  artist: "Queue Artist",
+  duration: 188,
 };
 
-describe("/api/mix", () => {
+describe("/api/queue", () => {
   beforeEach(() => {
     restoreMethods();
     __resetQueueServiceForTests();
@@ -54,7 +53,7 @@ describe("/api/mix", () => {
   });
 
   test("should reject requests without a track", async () => {
-    const response = await api.request("/mix", {
+    const response = await api.request("/queue", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -67,32 +66,29 @@ describe("/api/mix", () => {
     });
   });
 
-  test("should return the created mix count", async () => {
+  test("should forward requester metadata to the queue service", async () => {
     const queueService = getQueueService();
-    let requestedBy: Track["requestedBy"] | undefined;
+    const received: {
+      track: Track | null;
+      requestedBy?: Track["requestedBy"];
+    } = {
+      track: null,
+    };
 
     stubMethod(
       queueService,
-      "createMixFromTrack",
-      (async (_track: Track, options = {}) => {
-        requestedBy = options.requestedBy;
-        return [
-          baseTrack,
-          {
-            videoId: "mix-1",
-            title: "Mix Song 1",
-            artist: "Artist 1",
-            duration: 200,
-          },
-        ];
-      }) as typeof queueService.createMixFromTrack,
+      "addToQueue",
+      (async (track: Track, options = {}) => {
+        received.track = track;
+        received.requestedBy = options.requestedBy;
+      }) as typeof queueService.addToQueue,
     );
 
-    const response = await api.request("/mix", {
+    const response = await api.request("/queue", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        track: baseTrack,
+        track: queuedTrack,
         requestedBy: {
           profileId: "profile-a",
           profileName: "Alice",
@@ -101,45 +97,14 @@ describe("/api/mix", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(requestedBy).toEqual({
+    expect(received.track).toEqual(queuedTrack);
+    expect(received.requestedBy).toEqual({
       profileId: "profile-a",
       profileName: "Alice",
     });
     expect(await response.json()).toEqual({
       success: true,
-      data: {
-        message: "Added 2 tracks to queue",
-        count: 2,
-        tracks: [
-          baseTrack,
-          {
-            videoId: "mix-1",
-            title: "Mix Song 1",
-            artist: "Artist 1",
-            duration: 200,
-          },
-        ],
-      },
-    });
-  });
-
-  test("should surface service failures as 500 responses", async () => {
-    const queueService = getQueueService();
-
-    stubMethod(queueService, "createMixFromTrack", async () => {
-      throw new Error("mix failed");
-    });
-
-    const response = await api.request("/mix", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ track: baseTrack }),
-    });
-
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({
-      success: false,
-      error: "Failed to create mix",
+      data: { message: "Added to queue" },
     });
   });
 });

--- a/src/__tests__/api.sync.test.ts
+++ b/src/__tests__/api.sync.test.ts
@@ -3,12 +3,46 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import api from "../routes/api.ts";
+import {
+  __resetQueueServiceForTests,
+  getQueueService,
+} from "../services/queue.service.ts";
 import { __resetSyncServiceForTests } from "../services/sync.service.ts";
+
+type RestorableMethod = {
+  target: Record<string, unknown>;
+  key: string;
+  original: unknown;
+};
+
+const restores: RestorableMethod[] = [];
+
+function stubMethod<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  replacement: T[K],
+): void {
+  restores.push({
+    target: target as Record<string, unknown>,
+    key: key as string,
+    original: target[key],
+  });
+  target[key] = replacement;
+}
+
+function restoreMethods(): void {
+  while (restores.length > 0) {
+    const restore = restores.pop()!;
+    restore.target[restore.key] = restore.original;
+  }
+}
 
 describe("/api/sync", () => {
   let tempDir = "";
 
   beforeEach(() => {
+    restoreMethods();
+    __resetQueueServiceForTests();
     __resetSyncServiceForTests();
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
@@ -18,6 +52,8 @@ describe("/api/sync", () => {
   });
 
   afterEach(() => {
+    restoreMethods();
+    __resetQueueServiceForTests();
     __resetSyncServiceForTests();
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
@@ -32,10 +68,15 @@ describe("/api/sync", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         profileId: "profile-a",
+        profileName: "Alice",
         device: {
           id: "device-a",
-          name: "Desktop A",
+          reportedName: "Desktop A",
           kind: "desktop",
+          metadata: {
+            architecture: "arm64",
+            browserName: "Chrome",
+          },
         },
       }),
     });
@@ -45,6 +86,7 @@ describe("/api/sync", () => {
       success: boolean;
       data: {
         profileId: string;
+        profileName: string;
         devices: Array<{ id: string }>;
         deviceToken: string;
         pairCode: string;
@@ -53,8 +95,39 @@ describe("/api/sync", () => {
     };
     expect(payload.success).toBe(true);
     expect(payload.data.profileId).toBe("profile-a");
+    expect(payload.data.profileName).toBe("Alice");
     expect(payload.data.devices).toHaveLength(1);
     expect(payload.data.deviceToken).toBeTruthy();
+  });
+
+  test("should support legacy device.name payloads", async () => {
+    const response = await api.request("/sync/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        profileId: "profile-a",
+        device: {
+          id: "device-a",
+          name: "Legacy Desktop",
+          kind: "desktop",
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      data: {
+        profileName: string;
+        devices: Array<{
+          id: string;
+          reportedName: string;
+          displayName: string;
+        }>;
+      };
+    };
+    expect(payload.data.profileName).toBe("Legacy Desktop");
+    expect(payload.data.devices[0]?.reportedName).toBe("Legacy Desktop");
+    expect(payload.data.devices[0]?.displayName).toBe("Legacy Desktop");
   });
 
   test("should pair into an existing sync session", async () => {
@@ -65,7 +138,7 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-a",
-          name: "Desktop A",
+          reportedName: "Desktop A",
           kind: "desktop",
         },
       }),
@@ -82,7 +155,7 @@ describe("/api/sync", () => {
         profileId: "profile-b",
         device: {
           id: "device-b",
-          name: "Phone B",
+          reportedName: "Phone B",
           kind: "mobile",
         },
       }),
@@ -108,7 +181,7 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-a",
-          name: "Desktop A",
+          reportedName: "Desktop A",
           kind: "desktop",
         },
       }),
@@ -130,7 +203,7 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-a",
-          name: "Desktop A",
+          reportedName: "Desktop A",
           kind: "desktop",
         },
       }),
@@ -150,7 +223,7 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-a",
-          name: "Desktop A",
+          reportedName: "Desktop A",
           kind: "desktop",
         },
       }),
@@ -174,13 +247,13 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-a",
-          name: "Desktop A",
+          reportedName: "Desktop A",
           kind: "desktop",
         },
       }),
     });
     const created = (await createResponse.json()) as {
-      data: { sessionId: string };
+      data: { sessionId: string; deviceToken: string };
     };
 
     const resumeResponse = await api.request("/sync/session", {
@@ -191,7 +264,7 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-a",
-          name: "Desktop A",
+          reportedName: "Desktop A",
           kind: "desktop",
         },
       }),
@@ -213,7 +286,7 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-a",
-          name: "Desktop A",
+          reportedName: "Desktop A",
           kind: "desktop",
         },
       }),
@@ -230,7 +303,7 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-b",
-          name: "Phone B",
+          reportedName: "Phone B",
           kind: "mobile",
         },
       }),
@@ -275,7 +348,7 @@ describe("/api/sync", () => {
         profileId: "profile-a",
         device: {
           id: "device-b",
-          name: "Phone B",
+          reportedName: "Phone B",
           kind: "mobile",
         },
       }),
@@ -287,5 +360,122 @@ describe("/api/sync", () => {
       error: "Sync session repair required",
       code: "SYNC_REPAIR_REQUIRED",
     });
+  });
+
+  test("should update session profile name", async () => {
+    const queueService = getQueueService();
+    let renamedRequester:
+      | {
+          profileId: string;
+          profileName: string;
+        }
+      | undefined;
+
+    stubMethod(
+      queueService,
+      "renameRequesterProfile",
+      ((profileId: string, profileName: string) => {
+        renamedRequester = {
+          profileId,
+          profileName,
+        };
+      }) as typeof queueService.renameRequesterProfile,
+    );
+
+    const createResponse = await api.request("/sync/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        profileId: "profile-a",
+        profileName: "Alice",
+        device: {
+          id: "device-a",
+          reportedName: "Desktop A",
+          kind: "desktop",
+        },
+      }),
+    });
+    const created = (await createResponse.json()) as {
+      data: { sessionId: string; deviceToken: string };
+    };
+
+    const patchResponse = await api.request("/sync/session/profile", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId: created.data.sessionId,
+        profileName: "Bob",
+      }),
+    });
+
+    expect(patchResponse.status).toBe(200);
+    const patchPayload = (await patchResponse.json()) as {
+      success: boolean;
+      data: { profileName: string };
+    };
+    expect(patchPayload.success).toBe(true);
+    expect(patchPayload.data.profileName).toBe("Bob");
+    expect(renamedRequester).toEqual({
+      profileId: "profile-a",
+      profileName: "Bob",
+    });
+
+    const resumeResponse = await api.request("/sync/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId: created.data.sessionId,
+        profileId: "profile-a",
+        deviceToken: created.data.deviceToken,
+        device: {
+          id: "device-a",
+          reportedName: "Desktop A",
+          kind: "desktop",
+        },
+      }),
+    });
+    const resumePayload = (await resumeResponse.json()) as {
+      data: { profileName: string };
+    };
+    expect(resumePayload.data.profileName).toBe("Bob");
+  });
+
+  test("should rename a synced device via patch endpoint", async () => {
+    const createResponse = await api.request("/sync/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        profileId: "profile-a",
+        device: {
+          id: "device-a",
+          reportedName: "Desktop A",
+          kind: "desktop",
+        },
+      }),
+    });
+    const created = (await createResponse.json()) as {
+      data: { sessionId: string };
+    };
+
+    const renameResponse = await api.request("/sync/devices/device-a", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId: created.data.sessionId,
+        name: "Living Room Mac",
+      }),
+    });
+
+    expect(renameResponse.status).toBe(200);
+    const renamePayload = (await renameResponse.json()) as {
+      success: boolean;
+      data: {
+        devices: Array<{ id: string; displayName: string; customName: string | null }>;
+      };
+    };
+    expect(renamePayload.success).toBe(true);
+    expect(renamePayload.data.devices[0]?.id).toBe("device-a");
+    expect(renamePayload.data.devices[0]?.displayName).toBe("Living Room Mac");
+    expect(renamePayload.data.devices[0]?.customName).toBe("Living Room Mac");
   });
 });

--- a/src/__tests__/device-info.test.ts
+++ b/src/__tests__/device-info.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  detectDeviceInfo,
+  detectDeviceInfoSync,
+} from "../../frontend/src/utils/device-info.ts";
+
+describe("device-info detection", () => {
+  test("should enrich Apple Silicon compatibility strings with high-entropy hints", async () => {
+    const device = await detectDeviceInfo({
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+      platform: "MacIntel",
+      userAgentData: {
+        mobile: false,
+        platform: "macOS",
+        brands: [{ brand: "Google Chrome", version: "137" }],
+        getHighEntropyValues: async () => ({
+          architecture: "arm64",
+          bitness: "64",
+          platformVersion: "14.4.0",
+          uaFullVersion: "137.0.0.0",
+        }),
+      },
+    } as Navigator);
+
+    expect(device.kind).toBe("desktop");
+    expect(device.reportedName).toBe("Desktop · macOS");
+    expect(device.metadata).toEqual({
+      platformFamily: "macOS",
+      platformVersion: "14.4.0",
+      architecture: "ARM (64-bit)",
+      browserName: "Google Chrome",
+      browserVersion: "137.0.0.0",
+      model: null,
+    });
+  });
+
+  test("should detect generic Linux desktop browsers", () => {
+    const device = detectDeviceInfoSync({
+      userAgent:
+        "Mozilla/5.0 (X11; Linux x86_64; rv:138.0) Gecko/20100101 Firefox/138.0",
+      platform: "Linux x86_64",
+    } as Navigator);
+
+    expect(device.kind).toBe("desktop");
+    expect(device.reportedName).toBe("Desktop · Linux");
+    expect(device.metadata).toEqual({
+      platformFamily: "Linux",
+      platformVersion: null,
+      architecture: null,
+      browserName: "Firefox",
+      browserVersion: "138.0",
+      model: null,
+    });
+  });
+
+  test("should fall back to mobile UA heuristics without userAgentData", () => {
+    const device = detectDeviceInfoSync({
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1",
+      platform: "iPhone",
+    } as Navigator);
+
+    expect(device.kind).toBe("mobile");
+    expect(device.reportedName).toBe("Mobile · iOS");
+    expect(device.metadata?.browserName).toBe("Safari");
+  });
+
+  test("should not let viewport-only changes flip device kind", () => {
+    const narrowViewportDevice = detectDeviceInfoSync({
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+      platform: "Win32",
+      viewportWidth: 480,
+    } as Navigator & { viewportWidth: number });
+    const wideViewportDevice = detectDeviceInfoSync({
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+      platform: "Win32",
+      viewportWidth: 1440,
+    } as Navigator & { viewportWidth: number });
+
+    expect(narrowViewportDevice.kind).toBe("desktop");
+    expect(wideViewportDevice.kind).toBe("desktop");
+  });
+});

--- a/src/__tests__/mix.queue.service.test.ts
+++ b/src/__tests__/mix.queue.service.test.ts
@@ -196,6 +196,46 @@ describe("QueueService mix creation", () => {
     );
   });
 
+  test("should stamp requester metadata onto mix-created tracks", async () => {
+    const queueService = getQueueService();
+    const playerService = getPlayerService();
+    const musicService = getMusicService();
+
+    stubMethod(playerService, "stop", async () => {});
+    stubMethod(playerService, "isCurrentlyPlaying", () => false);
+    stubMethod(playerService, "play", async () => {
+      throw new Error("play() should not be used when playUrl() succeeds");
+    });
+    stubMethod(playerService, "playUrl", async () => {});
+    stubMethod(musicService, "getMixTracks", async () => mixTracks);
+    stubMethod(musicService, "getStreamUrl", async () => {
+      return { url: "https://stream/base-track", source: "yt-dlp" as const };
+    });
+    stubMethod(musicService, "getLyrics", async () => []);
+
+    const tracks = await queueService.createMixFromTrack(baseTrack, {
+      requestedBy: {
+        profileId: "profile-mix",
+        profileName: "Mix Master",
+      },
+    });
+    const state = queueService.getState();
+
+    expect(tracks.map((track) => track.requestedBy)).toEqual([
+      { profileId: "profile-mix", profileName: "Mix Master" },
+      { profileId: "profile-mix", profileName: "Mix Master" },
+      { profileId: "profile-mix", profileName: "Mix Master" },
+    ]);
+    expect(state.currentTrack?.requestedBy).toEqual({
+      profileId: "profile-mix",
+      profileName: "Mix Master",
+    });
+    expect(queueService.getQueue().map((track) => track.requestedBy)).toEqual([
+      { profileId: "profile-mix", profileName: "Mix Master" },
+      { profileId: "profile-mix", profileName: "Mix Master" },
+    ]);
+  });
+
   test("should fall back to the base track when fetching mix tracks fails", async () => {
     const queueService = getQueueService();
     const playerService = getPlayerService();

--- a/src/__tests__/queue.service.test.ts
+++ b/src/__tests__/queue.service.test.ts
@@ -194,5 +194,118 @@ describe("QueueService - seekTo functionality", () => {
         "Invalid queue index",
       );
     });
+
+    test("should preserve requestedBy on addToQueue", async () => {
+      const internalQueueService = queueService as unknown as {
+        currentTrack: Track | null;
+      };
+
+      internalQueueService.currentTrack = track("playing", "Playing");
+
+      await queueService.addToQueue({
+        ...track("track-1", "Track 1"),
+        requestedBy: {
+          profileId: "profile-a",
+          profileName: "Alice",
+        },
+      });
+
+      expect(queueService.getQueue()[0]?.requestedBy).toEqual({
+        profileId: "profile-a",
+        profileName: "Alice",
+      });
+    });
+
+    test("should stamp requestedBy via addToQueue options when track has none", async () => {
+      const internalQueueService = queueService as unknown as {
+        currentTrack: Track | null;
+      };
+
+      internalQueueService.currentTrack = track("playing", "Playing");
+
+      await queueService.addToQueue(track("track-2", "Track 2"), {
+        requestedBy: {
+          profileId: "profile-b",
+          profileName: "Bob",
+        },
+      });
+
+      expect(queueService.getQueue()[0]?.requestedBy).toEqual({
+        profileId: "profile-b",
+        profileName: "Bob",
+      });
+    });
+
+    test("should stamp requestedBy on appended tracks when fallback is provided", async () => {
+      const internalQueueService = queueService as unknown as {
+        currentTrack: Track | null;
+      };
+
+      internalQueueService.currentTrack = track("playing", "Playing");
+
+      await queueService.appendTracksToQueue(
+        [track("track-3", "Track 3"), track("track-4", "Track 4")],
+        "playlist",
+        {
+          requestedBy: {
+            profileId: "profile-c",
+            profileName: "Carol",
+          },
+        },
+      );
+
+      expect(queueService.getQueue().map((item) => item.requestedBy)).toEqual([
+        { profileId: "profile-c", profileName: "Carol" },
+        { profileId: "profile-c", profileName: "Carol" },
+      ]);
+    });
+
+    test("should rename requester profile across queue and playback state", () => {
+      const internalQueueService = queueService as unknown as {
+        queue: Track[];
+        currentTrack: Track | null;
+        lastPlayedTrack: Track | null;
+      };
+
+      internalQueueService.queue = [
+        {
+          ...track("track-5", "Track 5"),
+          requestedBy: {
+            profileId: "profile-d",
+            profileName: "Dana",
+          },
+        },
+      ];
+      internalQueueService.currentTrack = {
+        ...track("current", "Current"),
+        requestedBy: {
+          profileId: "profile-d",
+          profileName: "Dana",
+        },
+      };
+      internalQueueService.lastPlayedTrack = {
+        ...track("last", "Last"),
+        requestedBy: {
+          profileId: "profile-d",
+          profileName: "Dana",
+        },
+      };
+
+      queueService.renameRequesterProfile("profile-d", "Daphne");
+
+      const state = queueService.getState();
+      expect(state.currentTrack?.requestedBy).toEqual({
+        profileId: "profile-d",
+        profileName: "Daphne",
+      });
+      expect(state.lastPlayedTrack?.requestedBy).toEqual({
+        profileId: "profile-d",
+        profileName: "Daphne",
+      });
+      expect(queueService.getQueue()[0]?.requestedBy).toEqual({
+        profileId: "profile-d",
+        profileName: "Daphne",
+      });
+    });
   });
 });

--- a/src/__tests__/radio.queue.service.test.ts
+++ b/src/__tests__/radio.queue.service.test.ts
@@ -162,4 +162,42 @@ describe("QueueService radio mode", () => {
     ]);
     expect(queueService.getQueue()[0]?.queueOrigin).toBe("manual");
   });
+
+  test("should keep radio-generated tracks anonymous", async () => {
+    const queueService = getQueueService();
+    const playerService = getPlayerService();
+    const musicService = getMusicService();
+
+    stubMethod(playerService, "isCurrentlyPlaying", () => false);
+    stubMethod(playerService, "play", async () => {
+      throw new Error("play() should not be used when playUrl() succeeds");
+    });
+    stubMethod(playerService, "playUrl", async () => {});
+    stubMethod(musicService, "getMixTracks", async () => radioTracks);
+    stubMethod(musicService, "getStreamUrl", async (videoId: string) => {
+      return {
+        url: `https://stream/${videoId}`,
+        source: "youtube-ext" as const,
+      };
+    });
+    stubMethod(musicService, "getLyrics", async () => []);
+
+    await queueService.addToQueue({
+      ...baseTrack,
+      requestedBy: {
+        profileId: "profile-radio",
+        profileName: "Radio Starter",
+      },
+    });
+    queueService.enableRadio();
+    await queueService.playNext();
+
+    const state = queueService.getState();
+    expect(state.lastPlayedTrack?.requestedBy).toEqual({
+      profileId: "profile-radio",
+      profileName: "Radio Starter",
+    });
+    expect(state.currentTrack?.requestedBy).toBeUndefined();
+    expect(queueService.getQueue()[0]?.requestedBy).toBeUndefined();
+  });
 });

--- a/src/__tests__/requester.test.ts
+++ b/src/__tests__/requester.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { getCurrentRequester } from "../../frontend/src/utils/requester.ts";
+import type { LibrarySnapshot } from "../../frontend/src/types/library.ts";
+
+function createSnapshot(overrides: Partial<LibrarySnapshot> = {}): LibrarySnapshot {
+  return {
+    profileId: "profile-a",
+    profileName: "Alice",
+    deviceId: "device-a",
+    updatedAt: "2026-03-18T00:00:00.000Z",
+    syncSessionId: null,
+    syncDeviceToken: null,
+    favorites: [],
+    history: [],
+    savedMixes: [],
+    playlists: [],
+    pairedDevices: [],
+    ...overrides,
+  };
+}
+
+describe("getCurrentRequester", () => {
+  test("should return a stable requester reference for the same snapshot", () => {
+    const snapshot = createSnapshot();
+
+    const first = getCurrentRequester(snapshot);
+    const second = getCurrentRequester(snapshot);
+
+    expect(first).toBe(second);
+    expect(first).toEqual({
+      profileId: "profile-a",
+      profileName: "Alice",
+    });
+  });
+
+  test("should return undefined when profile identity is incomplete", () => {
+    expect(
+      getCurrentRequester(createSnapshot({ profileId: "", profileName: "Alice" })),
+    ).toBeUndefined();
+    expect(
+      getCurrentRequester(createSnapshot({ profileId: "profile-a", profileName: "" })),
+    ).toBeUndefined();
+  });
+});

--- a/src/__tests__/sync.service.test.ts
+++ b/src/__tests__/sync.service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { Database } from "bun:sqlite";
 import {
   __resetSyncServiceForTests,
   getSyncService,
@@ -10,6 +11,7 @@ import {
 
 describe("SyncService", () => {
   let tempDir = "";
+  let dbPath = "";
 
   beforeEach(() => {
     __resetSyncServiceForTests();
@@ -17,7 +19,8 @@ describe("SyncService", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
     tempDir = mkdtempSync(join(tmpdir(), "youtube-music-bot-sync-"));
-    process.env.SYNC_STATE_DB_PATH = join(tempDir, "sync-state.sqlite");
+    dbPath = join(tempDir, "sync-state.sqlite");
+    process.env.SYNC_STATE_DB_PATH = dbPath;
   });
 
   afterEach(() => {
@@ -29,16 +32,25 @@ describe("SyncService", () => {
     delete process.env.SYNC_STATE_DB_PATH;
   });
 
+  const desktopDevice = {
+    id: "device-a",
+    name: "Desktop A",
+    kind: "desktop" as const,
+  };
+
+  const phoneDevice = {
+    id: "device-b",
+    name: "Phone B",
+    kind: "mobile" as const,
+  };
+
   test("should create a session and reuse it on resume after service restart", () => {
     const syncService = getSyncService();
 
     const firstSession = syncService.createOrResumeSession({
       profileId: "profile-a",
-      device: {
-        id: "device-a",
-        name: "Desktop A",
-        kind: "desktop",
-      },
+      profileName: "Alice",
+      device: desktopDevice,
     });
 
     __resetSyncServiceForTests();
@@ -48,16 +60,13 @@ describe("SyncService", () => {
       sessionId: firstSession.sessionId,
       deviceToken: firstSession.deviceToken,
       profileId: "profile-a",
-      device: {
-        id: "device-a",
-        name: "Desktop A",
-        kind: "desktop",
-      },
+      device: desktopDevice,
     });
 
     expect(resumedSession.sessionId).toBe(firstSession.sessionId);
     expect(resumedSession.pairCode).toBe(firstSession.pairCode);
     expect(resumedSession.deviceToken).toBe(firstSession.deviceToken);
+    expect(resumedSession.profileName).toBe("Alice");
     expect(resumedSession.devices).toHaveLength(1);
   });
 
@@ -65,24 +74,18 @@ describe("SyncService", () => {
     const syncService = getSyncService();
     const session = syncService.createOrResumeSession({
       profileId: "profile-a",
-      device: {
-        id: "device-a",
-        name: "Desktop A",
-        kind: "desktop",
-      },
+      profileName: "Alice",
+      device: desktopDevice,
     });
 
     const pairedSession = syncService.pairToSession({
       pairCode: session.pairCode,
       profileId: "profile-b",
-      device: {
-        id: "device-b",
-        name: "Phone B",
-        kind: "mobile",
-      },
+      device: phoneDevice,
     });
 
     expect(pairedSession.profileId).toBe("profile-a");
+    expect(pairedSession.profileName).toBe("Alice");
     expect(pairedSession.deviceToken).toBeTruthy();
     expect(pairedSession.devices.map((device) => device.id)).toEqual([
       "device-a",
@@ -94,21 +97,13 @@ describe("SyncService", () => {
     const syncService = getSyncService();
     const session = syncService.createOrResumeSession({
       profileId: "profile-a",
-      device: {
-        id: "device-a",
-        name: "Desktop A",
-        kind: "desktop",
-      },
+      device: desktopDevice,
     });
 
     const pairedSession = syncService.pairToSession({
       pairCode: session.pairCode,
       profileId: "profile-a",
-      device: {
-        id: "device-b",
-        name: "Phone B",
-        kind: "mobile",
-      },
+      device: phoneDevice,
     });
 
     syncService.removeDevice(session.sessionId, "device-b");
@@ -122,11 +117,7 @@ describe("SyncService", () => {
         sessionId: session.sessionId,
         deviceToken: pairedSession.deviceToken,
         profileId: "profile-a",
-        device: {
-          id: "device-b",
-          name: "Phone B",
-          kind: "mobile",
-        },
+        device: phoneDevice,
       });
       throw new Error("Expected createOrResumeSession to fail");
     } catch (error) {
@@ -139,11 +130,7 @@ describe("SyncService", () => {
     const syncService = getSyncService();
     const session = syncService.createOrResumeSession({
       profileId: "profile-a",
-      device: {
-        id: "device-a",
-        name: "Desktop A",
-        kind: "desktop",
-      },
+      device: desktopDevice,
     });
 
     syncService.removeDevice(session.sessionId, "device-a");
@@ -161,11 +148,7 @@ describe("SyncService", () => {
     const syncService = getSyncService();
     const session = syncService.createOrResumeSession({
       profileId: "profile-a",
-      device: {
-        id: "device-a",
-        name: "Desktop A",
-        kind: "desktop",
-      },
+      device: desktopDevice,
     });
 
     __resetSyncServiceForTests();
@@ -175,13 +158,145 @@ describe("SyncService", () => {
       sessionId: session.sessionId,
       deviceToken: session.deviceToken,
       profileId: "profile-a",
-      device: {
-        id: "device-a",
-        name: "Desktop A",
-        kind: "desktop",
-      },
+      device: desktopDevice,
     });
 
     expect(resumedSession.devices[0]?.connected).toBe(false);
+  });
+
+  test("should update session profile name", () => {
+    const syncService = getSyncService();
+    const session = syncService.createOrResumeSession({
+      profileId: "profile-a",
+      profileName: "Alice",
+      device: desktopDevice,
+    });
+
+    const updated = syncService.updateProfileName(session.sessionId, "Bob");
+    expect(updated.profileName).toBe("Bob");
+
+    const resumed = syncService.createOrResumeSession({
+      sessionId: session.sessionId,
+      deviceToken: session.deviceToken,
+      profileId: "profile-a",
+      device: desktopDevice,
+    });
+    expect(resumed.profileName).toBe("Bob");
+  });
+
+  test("should preserve custom device name after reconnect metadata refresh", () => {
+    const syncService = getSyncService();
+    const session = syncService.createOrResumeSession({
+      profileId: "profile-a",
+      profileName: "Alice",
+      device: {
+        ...desktopDevice,
+        reportedName: "Desktop A",
+        metadata: {
+          architecture: "x86",
+          browserName: "Chrome",
+        },
+      },
+    });
+
+    const renamedDevices = syncService.renameDevice(
+      session.sessionId,
+      "device-a",
+      "Living Room Mac",
+    );
+    expect(renamedDevices[0]?.displayName).toBe("Living Room Mac");
+    expect(renamedDevices[0]?.name).toBe("Living Room Mac");
+
+    const resumed = syncService.createOrResumeSession({
+      sessionId: session.sessionId,
+      deviceToken: session.deviceToken,
+      profileId: "profile-a",
+      device: {
+        ...desktopDevice,
+        reportedName: "Desktop A Updated",
+        metadata: {
+          architecture: "arm64",
+          browserName: "Chrome",
+          browserVersion: "123",
+        },
+      },
+    });
+
+    const currentDevice = resumed.devices.find((device) => device.id === "device-a");
+    expect(currentDevice?.customName).toBe("Living Room Mac");
+    expect(currentDevice?.displayName).toBe("Living Room Mac");
+    expect(currentDevice?.reportedName).toBe("Desktop A Updated");
+    expect(currentDevice?.metadata.architecture).toBe("arm64");
+  });
+
+  test("should backfill profile_name and reported_name from legacy schema", () => {
+    const db = new Database(dbPath, { create: true });
+    db.exec(`
+      CREATE TABLE sync_sessions (
+        id TEXT PRIMARY KEY,
+        profile_id TEXT NOT NULL,
+        pair_code TEXT NOT NULL UNIQUE,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+    db.exec(`
+      CREATE TABLE sync_devices (
+        session_id TEXT NOT NULL,
+        device_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        paired_at TEXT NOT NULL,
+        last_seen_at TEXT NOT NULL,
+        revoked_at TEXT,
+        device_token_hash TEXT,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (session_id, device_id)
+      );
+    `);
+    db.exec(`
+      INSERT INTO sync_sessions (id, profile_id, pair_code, created_at, updated_at)
+      VALUES ('session-legacy', 'profile-legacy', 'ABC123', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z');
+    `);
+    db.exec(`
+      INSERT INTO sync_devices (
+        session_id,
+        device_id,
+        name,
+        kind,
+        paired_at,
+        last_seen_at,
+        revoked_at,
+        device_token_hash,
+        updated_at
+      ) VALUES (
+        'session-legacy',
+        'device-legacy',
+        'Legacy Desktop',
+        'desktop',
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z',
+        NULL,
+        NULL,
+        '2026-01-01T00:00:00.000Z'
+      );
+    `);
+    db.close();
+
+    const syncService = getSyncService();
+    const devices = syncService.getDevices("session-legacy");
+    expect(devices[0]?.reportedName).toBe("Legacy Desktop");
+    expect(devices[0]?.displayName).toBe("Legacy Desktop");
+
+    const paired = syncService.pairToSession({
+      pairCode: "ABC123",
+      profileId: "profile-new",
+      device: {
+        id: "device-new",
+        name: "Phone New",
+        kind: "mobile",
+      },
+    });
+    expect(paired.profileName).toBe("Legacy Desktop");
   });
 });

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -4,6 +4,7 @@ import { getMusicService } from "../services/music.service.ts";
 import { getQueueService } from "../services/queue.service.ts";
 import {
   getSyncService,
+  type SyncDeviceInput,
   SyncServiceError,
 } from "../services/sync.service.ts";
 import { getAppMetadata } from "../utils/app-metadata.ts";
@@ -17,16 +18,90 @@ const api = new Hono();
 
 type SyncDeviceRequest = {
   id: string;
-  name: string;
+  name?: string | null;
+  reportedName?: string | null;
   kind: "desktop" | "mobile";
+  metadata?: {
+    platformFamily?: string | null;
+    platformVersion?: string | null;
+    architecture?: string | null;
+    browserName?: string | null;
+    browserVersion?: string | null;
+    model?: string | null;
+  } | null;
 };
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseSyncDevice(device: SyncDeviceRequest | null | undefined): SyncDeviceInput | null {
+  if (!device) {
+    return null;
+  }
+
+  const id = normalizeText(device.id);
+  const reportedName = normalizeText(device.reportedName);
+  const legacyName = normalizeText(device.name);
+
+  if (!id || (!reportedName && !legacyName)) {
+    return null;
+  }
+
+  return {
+    id,
+    kind: device.kind === "mobile" ? "mobile" : "desktop",
+    reportedName,
+    name: legacyName,
+    metadata: device.metadata
+      ? {
+          platformFamily: normalizeText(device.metadata.platformFamily),
+          platformVersion: normalizeText(device.metadata.platformVersion),
+          architecture: normalizeText(device.metadata.architecture),
+          browserName: normalizeText(device.metadata.browserName),
+          browserVersion: normalizeText(device.metadata.browserVersion),
+          model: normalizeText(device.metadata.model),
+        }
+      : null,
+  };
+}
+
+function parseRequester(value: unknown): Track["requestedBy"] | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const requester = value as {
+    profileId?: unknown;
+    profileName?: unknown;
+  };
+  const profileId = normalizeText(requester.profileId);
+  const profileName = normalizeText(requester.profileName);
+
+  if (!profileId || !profileName) {
+    return undefined;
+  }
+
+  return {
+    profileId,
+    profileName,
+  };
+}
 
 function toSyncErrorResponse(error: unknown): {
   status: 404 | 409 | 500;
   body: ApiResponse;
 } {
   if (error instanceof SyncServiceError) {
-    if (error.code === "INVALID_PAIR_CODE") {
+    if (
+      error.code === "INVALID_PAIR_CODE" ||
+      error.code === "SYNC_DEVICE_NOT_FOUND"
+    ) {
       return {
         status: 404,
         body: {
@@ -172,7 +247,10 @@ api.get("/search", async (c) => {
  */
 api.post("/queue", async (c) => {
   try {
-    const body = await c.req.json<{ track: Track }>();
+    const body = await c.req.json<{
+      track: Track;
+      requestedBy?: Track["requestedBy"];
+    }>();
 
     if (!body.track || !body.track.videoId) {
       return c.json<ApiResponse>(
@@ -185,7 +263,9 @@ api.post("/queue", async (c) => {
     }
 
     const queueService = getQueueService();
-    await queueService.addToQueue(body.track);
+    await queueService.addToQueue(body.track, {
+      requestedBy: parseRequester(body.requestedBy),
+    });
 
     return c.json<ApiResponse>({
       success: true,
@@ -209,7 +289,10 @@ api.post("/queue", async (c) => {
  */
 api.post("/mix", async (c) => {
   try {
-    const body = await c.req.json<{ track: Track }>();
+    const body = await c.req.json<{
+      track: Track;
+      requestedBy?: Track["requestedBy"];
+    }>();
 
     if (!body.track || !body.track.videoId) {
       return c.json<ApiResponse>(
@@ -219,7 +302,9 @@ api.post("/mix", async (c) => {
     }
 
     const queueService = getQueueService();
-    const tracks = await queueService.createMixFromTrack(body.track);
+    const tracks = await queueService.createMixFromTrack(body.track, {
+      requestedBy: parseRequester(body.requestedBy),
+    });
 
     return c.json<ApiResponse>({
       success: true,
@@ -314,10 +399,12 @@ api.post("/sync/session", async (c) => {
       sessionId?: string | null;
       deviceToken?: string | null;
       profileId: string;
+      profileName?: string | null;
       device: SyncDeviceRequest;
     }>();
+    const device = parseSyncDevice(body.device);
 
-    if (!body.profileId || !body.device?.id || !body.device?.name) {
+    if (!body.profileId || !device) {
       return c.json<ApiResponse>(
         { success: false, error: "profileId and device are required" },
         400,
@@ -325,7 +412,13 @@ api.post("/sync/session", async (c) => {
     }
 
     const syncService = getSyncService();
-    const session = syncService.createOrResumeSession(body);
+    const session = syncService.createOrResumeSession({
+      sessionId: body.sessionId,
+      deviceToken: body.deviceToken,
+      profileId: body.profileId,
+      profileName: body.profileName,
+      device,
+    });
 
     return c.json<ApiResponse>({
       success: true,
@@ -349,8 +442,9 @@ api.post("/sync/pair", async (c) => {
       profileId: string;
       device: SyncDeviceRequest;
     }>();
+    const device = parseSyncDevice(body.device);
 
-    if (!body.pairCode || !body.profileId || !body.device?.id || !body.device?.name) {
+    if (!body.pairCode || !body.profileId || !device) {
       return c.json<ApiResponse>(
         { success: false, error: "pairCode, profileId and device are required" },
         400,
@@ -358,7 +452,11 @@ api.post("/sync/pair", async (c) => {
     }
 
     const syncService = getSyncService();
-    const session = syncService.pairToSession(body);
+    const session = syncService.pairToSession({
+      pairCode: body.pairCode,
+      profileId: body.profileId,
+      device,
+    });
 
     return c.json<ApiResponse>({
       success: true,
@@ -366,6 +464,43 @@ api.post("/sync/pair", async (c) => {
     });
   } catch (error) {
     console.error("Failed to pair sync session:", error);
+    const response = toSyncErrorResponse(error);
+    return c.json<ApiResponse>(response.body, response.status);
+  }
+});
+
+/**
+ * PATCH /api/sync/session/profile
+ * 更新同步 session 的使用者名稱
+ */
+api.patch("/sync/session/profile", async (c) => {
+  try {
+    const body = await c.req.json<{
+      sessionId: string;
+      profileName: string;
+    }>();
+
+    if (!body.sessionId || typeof body.profileName !== "string") {
+      return c.json<ApiResponse>(
+        { success: false, error: "sessionId and profileName are required" },
+        400,
+      );
+    }
+
+    const syncService = getSyncService();
+    const profile = syncService.updateProfileName(
+      body.sessionId,
+      body.profileName,
+    );
+    getQueueService().renameRequesterProfile(
+      profile.profileId,
+      profile.profileName,
+    );
+    return c.json<ApiResponse>({
+      success: true,
+      data: profile,
+    });
+  } catch (error) {
     const response = toSyncErrorResponse(error);
     return c.json<ApiResponse>(response.body, response.status);
   }
@@ -387,6 +522,38 @@ api.get("/sync/devices", (c) => {
 
   try {
     const devices = getSyncService().getDevices(sessionId);
+    return c.json<ApiResponse>({
+      success: true,
+      data: { devices },
+    });
+  } catch (error) {
+    const response = toSyncErrorResponse(error);
+    return c.json<ApiResponse>(response.body, response.status);
+  }
+});
+
+/**
+ * PATCH /api/sync/devices/:deviceId
+ * 更新裝置顯示名稱
+ */
+api.patch("/sync/devices/:deviceId", async (c) => {
+  const deviceId = c.req.param("deviceId");
+
+  try {
+    const body = await c.req.json<{ sessionId: string; name: string }>();
+
+    if (!deviceId || !body.sessionId || typeof body.name !== "string") {
+      return c.json<ApiResponse>(
+        { success: false, error: "sessionId and name are required" },
+        400,
+      );
+    }
+
+    const devices = getSyncService().renameDevice(
+      body.sessionId,
+      deviceId,
+      body.name,
+    );
     return c.json<ApiResponse>({
       success: true,
       data: { devices },
@@ -492,7 +659,10 @@ api.post("/queue/reorder", async (c) => {
  */
 api.post("/library/playlists/:playlistId/play", async (c) => {
   try {
-    const body = await c.req.json<{ tracks: Track[] }>();
+    const body = await c.req.json<{
+      tracks: Track[];
+      requestedBy?: Track["requestedBy"];
+    }>();
 
     if (!Array.isArray(body.tracks) || body.tracks.length === 0) {
       return c.json<ApiResponse>(
@@ -502,7 +672,9 @@ api.post("/library/playlists/:playlistId/play", async (c) => {
     }
 
     const queueService = getQueueService();
-    await queueService.replaceQueueWithTracks(body.tracks, "playlist");
+    await queueService.replaceQueueWithTracks(body.tracks, "playlist", {
+      requestedBy: parseRequester(body.requestedBy),
+    });
 
     return c.json<ApiResponse>({
       success: true,
@@ -523,7 +695,10 @@ api.post("/library/playlists/:playlistId/play", async (c) => {
  */
 api.post("/library/playlists/:playlistId/queue", async (c) => {
   try {
-    const body = await c.req.json<{ tracks: Track[] }>();
+    const body = await c.req.json<{
+      tracks: Track[];
+      requestedBy?: Track["requestedBy"];
+    }>();
 
     if (!Array.isArray(body.tracks) || body.tracks.length === 0) {
       return c.json<ApiResponse>(
@@ -533,7 +708,9 @@ api.post("/library/playlists/:playlistId/queue", async (c) => {
     }
 
     const queueService = getQueueService();
-    await queueService.appendTracksToQueue(body.tracks, "playlist");
+    await queueService.appendTracksToQueue(body.tracks, "playlist", {
+      requestedBy: parseRequester(body.requestedBy),
+    });
 
     return c.json<ApiResponse>({
       success: true,

--- a/src/services/queue.service.ts
+++ b/src/services/queue.service.ts
@@ -210,13 +210,19 @@ class QueueService {
   /**
    * 加入歌曲到播放清單
    */
-  async addToQueue(track: Track): Promise<void> {
-    this.insertManualTracks([track]);
+  async addToQueue(
+    track: Track,
+    options: { requestedBy?: Track["requestedBy"] } = {},
+  ): Promise<void> {
+    const requester = this.resolveRequester(options.requestedBy, track);
+    const normalizedTrack = this.withRequester(track, requester);
+    this.insertManualTracks([normalizedTrack]);
 
     log.info("Added to queue", {
-      videoId: track.videoId,
-      title: track.title,
-      artist: track.artist,
+      videoId: normalizedTrack.videoId,
+      title: normalizedTrack.title,
+      artist: normalizedTrack.artist,
+      requestedBy: normalizedTrack.requestedBy?.profileId ?? null,
     });
     this.broadcastQueueChange();
 
@@ -245,8 +251,17 @@ class QueueService {
    * 創建混合播放清單
    * 清空佇列，立即開始播放 Mix
    */
-  async createMixFromTrack(baseTrack: Track): Promise<Track[]> {
-    log.info("Creating mix", { baseTrack: baseTrack.title });
+  async createMixFromTrack(
+    baseTrack: Track,
+    options: { requestedBy?: Track["requestedBy"] } = {},
+  ): Promise<Track[]> {
+    const requester = this.resolveRequester(options.requestedBy, baseTrack);
+    const normalizedBaseTrack = this.withRequester(baseTrack, requester);
+
+    log.info("Creating mix", {
+      baseTrack: normalizedBaseTrack.title,
+      requestedBy: normalizedBaseTrack.requestedBy?.profileId ?? null,
+    });
     const mixRequestId = ++this.mixRequestId;
 
     // 停止當前播放
@@ -262,7 +277,7 @@ class QueueService {
     this.broadcastState();
 
     // 先加入基礎歌曲
-    this.queue.push(this.withOrigin(baseTrack, "mix"));
+    this.queue.push(this.withOrigin(normalizedBaseTrack, "mix"));
 
     log.info("Mix created, starting playback", {
       addedTracks: this.queue.length,
@@ -275,20 +290,26 @@ class QueueService {
     // 再背景補上推薦歌曲。
     let mixTracks: Track[] = [];
     try {
-      mixTracks = await getMusicService().getMixTracks(baseTrack.videoId, 10);
+      mixTracks = await getMusicService().getMixTracks(
+        normalizedBaseTrack.videoId,
+        10,
+      );
 
       // 如果期間又建立了新的 mix，就丟棄舊結果避免污染 queue。
       if (mixRequestId !== this.mixRequestId) {
         log.info("Discarding stale mix tracks", {
-          baseTrack: baseTrack.title,
+          baseTrack: normalizedBaseTrack.title,
           mixRequestId,
           currentMixRequestId: this.mixRequestId,
         });
-        return [baseTrack];
+        return [normalizedBaseTrack];
       }
 
       if (mixTracks.length > 0) {
-        this.queue.push(...mixTracks.map((track) => this.withOrigin(track, "mix")));
+        const normalizedMixTracks = mixTracks.map((track) =>
+          this.withOrigin(this.withRequester(track, requester), "mix"),
+        );
+        this.queue.push(...normalizedMixTracks);
         this.broadcastQueueChange();
 
         // 若 base song 已結束且播放器空閒，補上的 mix 要能自動接續播放。
@@ -300,7 +321,10 @@ class QueueService {
       log.warn("Failed to get mix tracks, playing base track only", { error });
     }
 
-    return [baseTrack, ...mixTracks];
+    return [
+      normalizedBaseTrack,
+      ...mixTracks.map((track) => this.withRequester(track, requester)),
+    ];
   }
 
   /**
@@ -605,10 +629,14 @@ class QueueService {
   async replaceQueueWithTracks(
     tracks: Track[],
     origin: QueueOrigin = "playlist",
+    options: { requestedBy?: Track["requestedBy"] } = {},
   ): Promise<void> {
     await getPlayerService().stop();
+    const requester = this.resolveRequester(options.requestedBy, null, tracks);
 
-    this.queue = tracks.map((track) => this.withOrigin(track, origin));
+    this.queue = tracks.map((track) =>
+      this.withOrigin(this.withRequester(track, requester), origin),
+    );
     this.currentTrack = null;
     this.currentPosition = 0;
     this.currentDuration = 0;
@@ -625,13 +653,17 @@ class QueueService {
   async appendTracksToQueue(
     tracks: Track[],
     origin: QueueOrigin = "playlist",
+    options: { requestedBy?: Track["requestedBy"] } = {},
   ): Promise<void> {
     if (tracks.length === 0) {
       return;
     }
+    const requester = this.resolveRequester(options.requestedBy, null, tracks);
 
     this.insertManualTracks(
-      tracks.map((track) => this.withOrigin(track, origin)),
+      tracks.map((track) =>
+        this.withOrigin(this.withRequester(track, requester), origin),
+      ),
       origin === "manual" || origin === "playlist",
     );
     this.broadcastQueueChange();
@@ -646,6 +678,60 @@ class QueueService {
     }
 
     this.maybeHydrateRadioQueue();
+  }
+
+  renameRequesterProfile(profileId: string, profileName: string): void {
+    const normalizedProfileId = profileId.trim();
+    const normalizedProfileName = profileName.trim();
+
+    if (!normalizedProfileId || !normalizedProfileName) {
+      return;
+    }
+
+    let didChange = false;
+
+    const renamedQueue = this.queue.map((track) => {
+      const nextTrack =
+        this.withRenamedRequester(
+        track,
+        normalizedProfileId,
+        normalizedProfileName,
+        ) ?? track;
+
+      if (nextTrack !== track) {
+        didChange = true;
+      }
+
+      return nextTrack;
+    });
+    const renamedCurrentTrack = this.withRenamedRequester(
+      this.currentTrack,
+      normalizedProfileId,
+      normalizedProfileName,
+    );
+    const renamedLastPlayedTrack = this.withRenamedRequester(
+      this.lastPlayedTrack,
+      normalizedProfileId,
+      normalizedProfileName,
+    );
+
+    if (renamedCurrentTrack !== this.currentTrack) {
+      didChange = true;
+    }
+
+    if (renamedLastPlayedTrack !== this.lastPlayedTrack) {
+      didChange = true;
+    }
+
+    if (!didChange) {
+      return;
+    }
+
+    this.queue = renamedQueue;
+    this.currentTrack = renamedCurrentTrack;
+    this.lastPlayedTrack = renamedLastPlayedTrack;
+    this.broadcastQueueChange();
+    this.broadcastState();
   }
 
   /**
@@ -718,6 +804,72 @@ class QueueService {
       queueOrigin: origin,
       radioGenerated: origin === "radio",
     };
+  }
+
+  private withRequester(
+    track: Track,
+    requestedBy?: Track["requestedBy"],
+  ): Track {
+    if (!isValidRequester(requestedBy)) {
+      return track;
+    }
+
+    if (
+      track.requestedBy?.profileId === requestedBy.profileId &&
+      track.requestedBy.profileName === requestedBy.profileName
+    ) {
+      return track;
+    }
+
+    return {
+      ...track,
+      requestedBy,
+    };
+  }
+
+  private withRenamedRequester(
+    track: Track | null,
+    profileId: string,
+    profileName: string,
+  ): Track | null {
+    if (
+      !track?.requestedBy ||
+      track.requestedBy.profileId !== profileId ||
+      track.requestedBy.profileName === profileName
+    ) {
+      return track;
+    }
+
+    return {
+      ...track,
+      requestedBy: {
+        ...track.requestedBy,
+        profileName,
+      },
+    };
+  }
+
+  private resolveRequester(
+    requestedBy?: Track["requestedBy"],
+    sourceTrack: Track | null = null,
+    sourceTracks: Track[] = [],
+  ): Track["requestedBy"] | undefined {
+    if (isValidRequester(requestedBy)) {
+      return requestedBy;
+    }
+
+    const sourceRequester = sourceTrack?.requestedBy;
+    if (isValidRequester(sourceRequester)) {
+      return sourceRequester;
+    }
+
+    for (const track of sourceTracks) {
+      if (isValidRequester(track.requestedBy)) {
+        return track.requestedBy;
+      }
+    }
+
+    return undefined;
   }
 
   private insertManualTracks(
@@ -851,6 +1003,14 @@ function isSameProgress(
     left.position === right.position &&
     left.duration === right.duration &&
     left.isPlaying === right.isPlaying
+  );
+}
+
+function isValidRequester(
+  requestedBy: Track["requestedBy"] | undefined,
+): requestedBy is NonNullable<Track["requestedBy"]> {
+  return Boolean(
+    requestedBy?.profileId?.trim() && requestedBy.profileName?.trim(),
   );
 }
 

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -4,16 +4,31 @@ import { createHash, randomBytes } from "node:crypto";
 import type { ServerWebSocket } from "bun";
 import { Database } from "bun:sqlite";
 
+export interface SyncDeviceMetadata {
+  platformFamily: string | null;
+  platformVersion: string | null;
+  architecture: string | null;
+  browserName: string | null;
+  browserVersion: string | null;
+  model: string | null;
+}
+
 export interface SyncDeviceInput {
   id: string;
-  name: string;
+  name?: string | null;
+  reportedName?: string | null;
   kind: "desktop" | "mobile";
+  metadata?: Partial<SyncDeviceMetadata> | null;
 }
 
 export interface SyncSessionDevice {
   id: string;
-  name: string;
+  name: string; // legacy: equals displayName
+  displayName: string;
+  reportedName: string;
+  customName: string | null;
   kind: "desktop" | "mobile";
+  metadata: SyncDeviceMetadata;
   connected: boolean;
   pairedAt: string;
   lastSeenAt: string;
@@ -23,8 +38,15 @@ export interface SyncSessionResponse {
   sessionId: string;
   pairCode: string;
   profileId: string;
+  profileName: string;
   deviceToken: string;
   devices: SyncSessionDevice[];
+}
+
+export interface SyncProfileResponse {
+  sessionId: string;
+  profileId: string;
+  profileName: string;
 }
 
 type SyncSocketData = {
@@ -35,6 +57,7 @@ type SyncSocketData = {
 type SyncSessionRow = {
   id: string;
   profile_id: string;
+  profile_name: string;
   pair_code: string;
   created_at: string;
   updated_at: string;
@@ -44,7 +67,15 @@ type SyncDeviceRow = {
   session_id: string;
   device_id: string;
   name: string;
+  reported_name: string | null;
+  custom_name: string | null;
   kind: "desktop" | "mobile";
+  platform_family: string | null;
+  platform_version: string | null;
+  architecture: string | null;
+  browser_name: string | null;
+  browser_version: string | null;
+  model: string | null;
   paired_at: string;
   last_seen_at: string;
   revoked_at: string | null;
@@ -53,13 +84,16 @@ type SyncDeviceRow = {
 };
 
 const PAIR_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const DEFAULT_PROFILE_NAME = "未命名使用者";
+const DEFAULT_REPORTED_DEVICE_NAME = "Unknown device";
 
 export class SyncServiceError extends Error {
   constructor(
     public readonly code:
       | "SYNC_SESSION_NOT_FOUND"
       | "SYNC_REPAIR_REQUIRED"
-      | "INVALID_PAIR_CODE",
+      | "INVALID_PAIR_CODE"
+      | "SYNC_DEVICE_NOT_FOUND",
     message: string,
   ) {
     super(message);
@@ -85,6 +119,51 @@ function hashDeviceToken(deviceToken: string): string {
 
 function createDeviceToken(): string {
   return randomBytes(24).toString("base64url");
+}
+
+function normalizeNullableText(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeProfileName(value: string | null | undefined): string {
+  return normalizeNullableText(value) ?? DEFAULT_PROFILE_NAME;
+}
+
+function normalizeDeviceMetadata(
+  metadata: Partial<SyncDeviceMetadata> | null | undefined,
+): SyncDeviceMetadata {
+  return {
+    platformFamily: normalizeNullableText(metadata?.platformFamily),
+    platformVersion: normalizeNullableText(metadata?.platformVersion),
+    architecture: normalizeNullableText(metadata?.architecture),
+    browserName: normalizeNullableText(metadata?.browserName),
+    browserVersion: normalizeNullableText(metadata?.browserVersion),
+    model: normalizeNullableText(metadata?.model),
+  };
+}
+
+function normalizeReportedName(input: SyncDeviceInput): string {
+  return (
+    normalizeNullableText(input.reportedName) ??
+    normalizeNullableText(input.name) ??
+    DEFAULT_REPORTED_DEVICE_NAME
+  );
+}
+
+function resolveDisplayName(
+  customName: string | null | undefined,
+  reportedName: string | null | undefined,
+): string {
+  return (
+    normalizeNullableText(customName) ??
+    normalizeNullableText(reportedName) ??
+    DEFAULT_REPORTED_DEVICE_NAME
+  );
 }
 
 class SyncService {
@@ -118,6 +197,7 @@ class SyncService {
     sessionId?: string | null;
     deviceToken?: string | null;
     profileId: string;
+    profileName?: string | null;
     device: SyncDeviceInput;
   }): SyncSessionResponse {
     const requestedSessionId = input.sessionId?.trim() || null;
@@ -155,7 +235,13 @@ class SyncService {
       return this.serializeSession(session, requestedDeviceToken);
     }
 
-    const session = this.createSession({ profileId: input.profileId });
+    const session = this.createSession({
+      profileId: input.profileId,
+      profileName:
+        normalizeNullableText(input.profileName) ??
+        normalizeNullableText(input.device.reportedName) ??
+        normalizeNullableText(input.device.name),
+    });
     const deviceToken = createDeviceToken();
 
     this.upsertDevice(session.id, input.device, deviceToken);
@@ -193,6 +279,82 @@ class SyncService {
     return this.serializeDevices(session.id);
   }
 
+  updateProfileName(sessionId: string, profileName: string): SyncProfileResponse {
+    const session = this.getSessionById(sessionId);
+    if (!session) {
+      throw new SyncServiceError(
+        "SYNC_SESSION_NOT_FOUND",
+        "Sync session not found",
+      );
+    }
+
+    const now = new Date().toISOString();
+    const normalizedProfileName = normalizeProfileName(profileName);
+
+    this.db
+      .query(
+        `UPDATE sync_sessions
+           SET profile_name = ?1,
+               updated_at = ?2
+         WHERE id = ?3`,
+      )
+      .run(normalizedProfileName, now, sessionId);
+
+    this.broadcastToSession(sessionId, {
+      type: "sync_profile_updated",
+      sessionId,
+      profileId: session.profile_id,
+      profileName: normalizedProfileName,
+    });
+
+    return {
+      sessionId,
+      profileId: session.profile_id,
+      profileName: normalizedProfileName,
+    };
+  }
+
+  renameDevice(
+    sessionId: string,
+    deviceId: string,
+    name: string,
+  ): SyncSessionDevice[] {
+    const session = this.getSessionById(sessionId);
+    if (!session) {
+      throw new SyncServiceError(
+        "SYNC_SESSION_NOT_FOUND",
+        "Sync session not found",
+      );
+    }
+
+    const device = this.getActiveDevice(sessionId, deviceId);
+    if (!device) {
+      throw new SyncServiceError("SYNC_DEVICE_NOT_FOUND", "Sync device not found");
+    }
+
+    const now = new Date().toISOString();
+    const customName = normalizeNullableText(name);
+
+    this.db.transaction(() => {
+      this.db
+        .query(
+          `UPDATE sync_devices
+             SET custom_name = ?1,
+                 name = COALESCE(?1, reported_name, name),
+                 updated_at = ?2
+           WHERE session_id = ?3
+             AND device_id = ?4
+             AND revoked_at IS NULL`,
+        )
+        .run(customName, now, sessionId, deviceId);
+
+      this.updateSessionTimestamp(sessionId, now);
+    })();
+
+    this.broadcastDevices(sessionId);
+    return this.serializeDevices(sessionId);
+  }
+
   removeDevice(sessionId: string, deviceId: string): void {
     const session = this.getSessionById(sessionId);
 
@@ -225,9 +387,7 @@ class SyncService {
       if (this.countActiveDevices(sessionId) === 0) {
         this.db.query("DELETE FROM sync_sessions WHERE id = ?1").run(sessionId);
       } else {
-        this.db
-          .query("UPDATE sync_sessions SET updated_at = ?1 WHERE id = ?2")
-          .run(now, sessionId);
+        this.updateSessionTimestamp(sessionId, now);
       }
     })();
 
@@ -362,6 +522,7 @@ class SyncService {
       CREATE TABLE IF NOT EXISTS sync_sessions (
         id TEXT PRIMARY KEY,
         profile_id TEXT NOT NULL,
+        profile_name TEXT,
         pair_code TEXT NOT NULL UNIQUE,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
@@ -372,7 +533,15 @@ class SyncService {
         session_id TEXT NOT NULL,
         device_id TEXT NOT NULL,
         name TEXT NOT NULL,
+        reported_name TEXT,
+        custom_name TEXT,
         kind TEXT NOT NULL,
+        platform_family TEXT,
+        platform_version TEXT,
+        architecture TEXT,
+        browser_name TEXT,
+        browser_version TEXT,
+        model TEXT,
         paired_at TEXT NOT NULL,
         last_seen_at TEXT NOT NULL,
         revoked_at TEXT,
@@ -382,13 +551,85 @@ class SyncService {
         FOREIGN KEY (session_id) REFERENCES sync_sessions(id) ON DELETE CASCADE
       );
     `);
+
+    this.ensureColumn("sync_sessions", "profile_name", "TEXT");
+    this.ensureColumn("sync_devices", "reported_name", "TEXT");
+    this.ensureColumn("sync_devices", "custom_name", "TEXT");
+    this.ensureColumn("sync_devices", "platform_family", "TEXT");
+    this.ensureColumn("sync_devices", "platform_version", "TEXT");
+    this.ensureColumn("sync_devices", "architecture", "TEXT");
+    this.ensureColumn("sync_devices", "browser_name", "TEXT");
+    this.ensureColumn("sync_devices", "browser_version", "TEXT");
+    this.ensureColumn("sync_devices", "model", "TEXT");
+
+    this.backfillLegacyData();
   }
 
-  private createSession(input: { profileId: string }): SyncSessionRow {
+  private ensureColumn(tableName: string, columnName: string, definition: string): void {
+    const columns = this.db
+      .query(`PRAGMA table_info(${tableName})`)
+      .all() as Array<{ name: string }>;
+
+    if (columns.some((column) => column.name === columnName)) {
+      return;
+    }
+
+    this.db.exec(
+      `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition};`,
+    );
+  }
+
+  private backfillLegacyData(): void {
+    this.db.exec(`
+      UPDATE sync_devices
+         SET reported_name = COALESCE(
+               NULLIF(TRIM(reported_name), ''),
+               NULLIF(TRIM(name), ''),
+               '${DEFAULT_REPORTED_DEVICE_NAME}'
+             )
+       WHERE reported_name IS NULL OR TRIM(reported_name) = '';
+    `);
+
+    this.db.exec(`
+      UPDATE sync_devices
+         SET name = COALESCE(
+               NULLIF(TRIM(custom_name), ''),
+               NULLIF(TRIM(reported_name), ''),
+               NULLIF(TRIM(name), ''),
+               '${DEFAULT_REPORTED_DEVICE_NAME}'
+             );
+    `);
+
+    this.db.exec(`
+      UPDATE sync_sessions
+         SET profile_name = COALESCE(
+               (
+                 SELECT COALESCE(
+                   NULLIF(TRIM(d.custom_name), ''),
+                   NULLIF(TRIM(d.reported_name), ''),
+                   NULLIF(TRIM(d.name), '')
+                 )
+                   FROM sync_devices d
+                  WHERE d.session_id = sync_sessions.id
+                    AND d.revoked_at IS NULL
+               ORDER BY d.paired_at ASC
+                  LIMIT 1
+               ),
+               '${DEFAULT_PROFILE_NAME}'
+             )
+       WHERE profile_name IS NULL OR TRIM(profile_name) = '';
+    `);
+  }
+
+  private createSession(input: {
+    profileId: string;
+    profileName?: string | null;
+  }): SyncSessionRow {
     const now = new Date().toISOString();
     const session: SyncSessionRow = {
       id: crypto.randomUUID(),
       profile_id: input.profileId,
+      profile_name: normalizeProfileName(input.profileName),
       pair_code: this.generatePairCode(),
       created_at: now,
       updated_at: now,
@@ -396,12 +637,20 @@ class SyncService {
 
     this.db
       .query(
-        `INSERT INTO sync_sessions (id, profile_id, pair_code, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5)`,
+        `INSERT INTO sync_sessions (
+           id,
+           profile_id,
+           profile_name,
+           pair_code,
+           created_at,
+           updated_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
       )
       .run(
         session.id,
         session.profile_id,
+        session.profile_name,
         session.pair_code,
         session.created_at,
         session.updated_at,
@@ -417,6 +666,8 @@ class SyncService {
   ): void {
     const now = new Date().toISOString();
     const tokenHash = hashDeviceToken(deviceToken);
+    const reportedName = normalizeReportedName(deviceInput);
+    const metadata = normalizeDeviceMetadata(deviceInput.metadata);
 
     this.db.transaction(() => {
       this.db
@@ -425,17 +676,34 @@ class SyncService {
              session_id,
              device_id,
              name,
+             reported_name,
+             custom_name,
              kind,
+             platform_family,
+             platform_version,
+             architecture,
+             browser_name,
+             browser_version,
+             model,
              paired_at,
              last_seen_at,
              revoked_at,
              device_token_hash,
              updated_at
            )
-           VALUES (?1, ?2, ?3, ?4, ?5, ?5, NULL, ?6, ?5)
+           VALUES (
+             ?1, ?2, ?3, ?3, NULL, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11, NULL, ?12, ?11
+           )
            ON CONFLICT(session_id, device_id) DO UPDATE SET
-             name = excluded.name,
+             name = COALESCE(custom_name, excluded.reported_name, excluded.name),
+             reported_name = excluded.reported_name,
              kind = excluded.kind,
+             platform_family = excluded.platform_family,
+             platform_version = excluded.platform_version,
+             architecture = excluded.architecture,
+             browser_name = excluded.browser_name,
+             browser_version = excluded.browser_version,
+             model = excluded.model,
              last_seen_at = excluded.last_seen_at,
              revoked_at = NULL,
              device_token_hash = excluded.device_token_hash,
@@ -444,15 +712,19 @@ class SyncService {
         .run(
           sessionId,
           deviceInput.id,
-          deviceInput.name,
+          reportedName,
           deviceInput.kind,
+          metadata.platformFamily,
+          metadata.platformVersion,
+          metadata.architecture,
+          metadata.browserName,
+          metadata.browserVersion,
+          metadata.model,
           now,
           tokenHash,
         );
 
-      this.db
-        .query("UPDATE sync_sessions SET updated_at = ?1 WHERE id = ?2")
-        .run(now, sessionId);
+      this.updateSessionTimestamp(sessionId, now);
     })();
   }
 
@@ -462,32 +734,52 @@ class SyncService {
     deviceToken: string,
   ): void {
     const now = new Date().toISOString();
+    const reportedName = normalizeReportedName(deviceInput);
+    const metadata = normalizeDeviceMetadata(deviceInput.metadata);
+
     this.db.transaction(() => {
       this.db
         .query(
           `UPDATE sync_devices
-             SET name = ?1,
+             SET name = COALESCE(custom_name, ?1),
+                 reported_name = ?1,
                  kind = ?2,
-                 last_seen_at = ?3,
-                 updated_at = ?3,
-                 device_token_hash = ?4
-           WHERE session_id = ?5
-             AND device_id = ?6
+                 platform_family = ?3,
+                 platform_version = ?4,
+                 architecture = ?5,
+                 browser_name = ?6,
+                 browser_version = ?7,
+                 model = ?8,
+                 last_seen_at = ?9,
+                 updated_at = ?9,
+                 device_token_hash = ?10
+           WHERE session_id = ?11
+             AND device_id = ?12
              AND revoked_at IS NULL`,
         )
         .run(
-          deviceInput.name,
+          reportedName,
           deviceInput.kind,
+          metadata.platformFamily,
+          metadata.platformVersion,
+          metadata.architecture,
+          metadata.browserName,
+          metadata.browserVersion,
+          metadata.model,
           now,
           hashDeviceToken(deviceToken),
           sessionId,
           deviceInput.id,
         );
 
-      this.db
-        .query("UPDATE sync_sessions SET updated_at = ?1 WHERE id = ?2")
-        .run(now, sessionId);
+      this.updateSessionTimestamp(sessionId, now);
     })();
+  }
+
+  private updateSessionTimestamp(sessionId: string, now: string): void {
+    this.db
+      .query("UPDATE sync_sessions SET updated_at = ?1 WHERE id = ?2")
+      .run(now, sessionId);
   }
 
   private getSessionById(sessionId: string): SyncSessionRow | null {
@@ -600,6 +892,7 @@ class SyncService {
       sessionId: session.id,
       pairCode: session.pair_code,
       profileId: session.profile_id,
+      profileName: normalizeProfileName(session.profile_name),
       deviceToken,
       devices: this.serializeDevices(session.id),
     };
@@ -608,8 +901,20 @@ class SyncService {
   private serializeDevices(sessionId: string): SyncSessionDevice[] {
     return this.listActiveDevices(sessionId).map((device) => ({
       id: device.device_id,
-      name: device.name,
+      name: resolveDisplayName(device.custom_name, device.reported_name),
+      displayName: resolveDisplayName(device.custom_name, device.reported_name),
+      reportedName:
+        normalizeNullableText(device.reported_name) ?? DEFAULT_REPORTED_DEVICE_NAME,
+      customName: normalizeNullableText(device.custom_name),
       kind: device.kind,
+      metadata: {
+        platformFamily: normalizeNullableText(device.platform_family),
+        platformVersion: normalizeNullableText(device.platform_version),
+        architecture: normalizeNullableText(device.architecture),
+        browserName: normalizeNullableText(device.browser_name),
+        browserVersion: normalizeNullableText(device.browser_version),
+        model: normalizeNullableText(device.model),
+      },
       connected: this.socketByDeviceKey.has(
         this.getSocketKey(device.session_id, device.device_id),
       ),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,10 @@
 export type QueueOrigin = "manual" | "mix" | "radio" | "playlist";
 
+export interface TrackRequester {
+  profileId: string;
+  profileName: string;
+}
+
 // 歌曲資訊
 export interface Track {
   videoId: string;
@@ -7,6 +12,7 @@ export interface Track {
   artist: string;
   duration: number; // 秒
   thumbnail?: string;
+  requestedBy?: TrackRequester;
   queueOrigin?: QueueOrigin;
   radioGenerated?: boolean;
 }

--- a/src/websocket/sync-handler.ts
+++ b/src/websocket/sync-handler.ts
@@ -4,6 +4,18 @@ import {
   SyncServiceError,
 } from "../services/sync.service.ts";
 
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function asMetadata(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
 export function handleSyncWebSocketOpen(_ws: ServerWebSocket<any>): void {
   // 等待客戶端送出 register 訊息
 }
@@ -17,18 +29,31 @@ export function handleSyncWebSocketMessage(
     const syncService = getSyncService();
 
     switch (data.type) {
-      case "sync_register":
+      case "sync_register": {
+        const metadata = asMetadata(data.deviceMetadata ?? data.metadata);
         syncService.registerConnection(ws, {
           sessionId: String(data.sessionId ?? ""),
           device: {
             id: String(data.deviceId ?? ""),
-            name: String(data.deviceName ?? ""),
+            reportedName: asString(data.reportedName) ?? asString(data.deviceName),
+            name: asString(data.deviceName),
             kind:
               data.deviceKind === "mobile" ? "mobile" : "desktop",
+            metadata: metadata
+              ? {
+                  platformFamily: asString(metadata.platformFamily),
+                  platformVersion: asString(metadata.platformVersion),
+                  architecture: asString(metadata.architecture),
+                  browserName: asString(metadata.browserName),
+                  browserVersion: asString(metadata.browserVersion),
+                  model: asString(metadata.model),
+                }
+              : null,
           },
           deviceToken: String(data.deviceToken ?? ""),
         });
         break;
+      }
 
       case "sync_snapshot":
         syncService.relaySnapshot(


### PR DESCRIPTION
## Summary
- merge the latest `codex/dev` changes into `main`
- includes the merged #13 / #14 sync identity work from PR #15
- adds sync session profile names, per-device rename support, richer device metadata, and requester attribution in queue/player UI

## Testing
- bun test src/__tests__/sync.service.test.ts src/__tests__/api.sync.test.ts src/__tests__/queue.service.test.ts src/__tests__/api.playback.test.ts src/__tests__/api.playlists.test.ts src/__tests__/api.mix.test.ts src/__tests__/api.queue.test.ts src/__tests__/mix.queue.service.test.ts src/__tests__/radio.queue.service.test.ts
- bun test src/__tests__/device-info.test.ts
- bun test src/__tests__/requester.test.ts
- npm --prefix frontend run build