### PR TITLE
Hotfix: bump app version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-music-bot",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "description": "YouTube Music 點歌機器人 WebUI",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the app version from `0.2.2` to `0.3.1`
- keeps the release line consistent with the merged sync identity changes and this follow-up hotfix
- updates the shared version source in the root `package.json`, which feeds backend and frontend build metadata

## Testing
- bun test src/__tests__/version-metadata.test.ts src/__tests__/api.system.test.ts
- npm --prefix frontend run build