### PR TITLE
release: 0.7.8 volume playback fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-music-bot",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "YouTube Music 點歌機器人 WebUI",
   "type": "module",
   "scripts": {

--- a/src/__tests__/api.discover.test.ts
+++ b/src/__tests__/api.discover.test.ts
@@ -100,7 +100,7 @@ describe("/api/discover", () => {
     stubMethod(
       discoverService,
       "getMarketsResponse",
-      (() => payload) as typeof discoverService.getMarketsResponse,
+      (async () => payload) as typeof discoverService.getMarketsResponse,
     );
 
     const response = await api.request("/discover/markets");

--- a/src/__tests__/discover.service.test.ts
+++ b/src/__tests__/discover.service.test.ts
@@ -104,14 +104,14 @@ describe("DiscoverService", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  test("returns configured markets and top requested tracks", () => {
+  test("returns configured markets and top requested tracks", async () => {
     service.recordTrackRequests([
       createTrack("track-1", "Track One"),
       createTrack("track-2", "Track Two"),
       createTrack("track-1", "Track One"),
     ]);
 
-    const response = service.getMarketsResponse();
+    const response = await service.getMarketsResponse();
 
     expect(response.defaultMarket).toBe(DEFAULT_DISCOVER_MARKET);
     expect(response.markets).toEqual(DISCOVER_MARKETS);
@@ -125,6 +125,70 @@ describe("DiscoverService", () => {
         title: "Track One",
       },
     });
+  });
+
+  test("preserves an existing catalog duration when a later request reports 0", async () => {
+    service.recordTrackRequests([
+      createTrack("track-1", "Track One"),
+    ]);
+    service.recordTrackRequests([
+      {
+        ...createTrack("track-1", "Track One"),
+        duration: 0,
+      },
+    ]);
+
+    const response = await service.getMarketsResponse();
+
+    expect(response.topRequested[0]?.track.duration).toBe(180);
+  });
+
+  test("hydrates missing durations for top requested tracks and persists the backfill", async () => {
+    service.recordTrackRequests([
+      {
+        ...createTrack("track-1", "Track One"),
+        duration: 0,
+      },
+    ]);
+
+    let metadataCalls = 0;
+    (
+      service as unknown as {
+        getDiscoverVideoMetadata: (
+          market: DiscoverMarketCode,
+          videoId: string,
+        ) => Promise<{ duration?: number; artist?: string } | null>;
+      }
+    ).getDiscoverVideoMetadata = async (market, videoId) => {
+      metadataCalls++;
+      expect(market).toBe(DEFAULT_DISCOVER_MARKET);
+      expect(videoId).toBe("track-1");
+      return {
+        duration: 215,
+      };
+    };
+
+    const firstResponse = await service.getMarketsResponse();
+
+    expect(firstResponse.topRequested[0]?.track.duration).toBe(215);
+    expect(metadataCalls).toBe(1);
+
+    (
+      service as unknown as {
+        getDiscoverVideoMetadata: (
+          market: DiscoverMarketCode,
+          videoId: string,
+        ) => Promise<{ duration?: number; artist?: string } | null>;
+      }
+    ).getDiscoverVideoMetadata = async () => {
+      metadataCalls++;
+      return null;
+    };
+
+    const secondResponse = await service.getMarketsResponse();
+
+    expect(secondResponse.topRequested[0]?.track.duration).toBe(215);
+    expect(metadataCalls).toBe(1);
   });
 
   test("normalizes invalid market input back to TW", async () => {

--- a/src/__tests__/mix.queue.service.test.ts
+++ b/src/__tests__/mix.queue.service.test.ts
@@ -75,6 +75,22 @@ function expectMixTrack(track: Track, expectedTrack: Track): void {
   });
 }
 
+function suppressNextTrackPreload(
+  queueService: ReturnType<typeof getQueueService>,
+): void {
+  const queue = queueService as unknown as {
+    syncNextTrackPreload: (options?: { force?: boolean }) => Promise<boolean>;
+  };
+
+  stubMethod(queue, "syncNextTrackPreload", async () => false);
+}
+
+function stubTrackLoudness(
+  musicService: ReturnType<typeof getMusicService>,
+): void {
+  stubMethod(musicService, "getTrackLoudness", async () => null);
+}
+
 describe("QueueService mix creation", () => {
   beforeEach(() => {
     restoreMethods();
@@ -98,6 +114,9 @@ describe("QueueService mix creation", () => {
     let playUrlCalls = 0;
     let getMixTracksCalls = 0;
     let getStreamUrlCalls = 0;
+
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
 
     stubMethod(playerService, "stop", async () => {
       stopCalls++;
@@ -156,6 +175,9 @@ describe("QueueService mix creation", () => {
       notifyMixFetchStarted = resolve;
     });
 
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
+
     stubMethod(playerService, "stop", async () => {});
     stubMethod(playerService, "play", async () => {
       throw new Error("play() should not be used when playUrl() succeeds");
@@ -201,6 +223,9 @@ describe("QueueService mix creation", () => {
     const playerService = getPlayerService();
     const musicService = getMusicService();
 
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
+
     stubMethod(playerService, "stop", async () => {});
     stubMethod(playerService, "isCurrentlyPlaying", () => false);
     stubMethod(playerService, "play", async () => {
@@ -242,6 +267,9 @@ describe("QueueService mix creation", () => {
     const musicService = getMusicService();
     let playUrlCalls = 0;
 
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
+
     stubMethod(playerService, "stop", async () => {});
     stubMethod(playerService, "play", async () => {
       throw new Error("play() should not be used when playUrl() succeeds");
@@ -266,30 +294,43 @@ describe("QueueService mix creation", () => {
     expect(state.queue).toEqual([]);
   });
 
-  test("should ignore a delayed exit from the intentionally stopped previous player", async () => {
+  test("should detach the previous session before starting mix playback", async () => {
     const queueService = getQueueService();
     const playerService = getPlayerService();
     const musicService = getMusicService();
+    let killCalls = 0;
     const oldProcess = {
-      kill: () => true,
+      kill: () => {
+        killCalls++;
+        return true;
+      },
     } as unknown as ChildProcess;
+    const oldSession = {
+      id: 1,
+      purpose: "active" as const,
+      source: { type: "stream" as const, value: "https://stream/old-track" },
+      volumeMultiplier: 1,
+      targetVolume: 70,
+      process: oldProcess,
+      ipcSocket: null,
+      ipcPath: "/tmp/test-mpv.sock",
+      ipcConnectRetries: 0,
+      eofHandled: false,
+      ready: true,
+      trackId: "old-track",
+      confirmation: null,
+    };
     const player = playerService as unknown as {
-      mpvProcess: ChildProcess | null;
+      activeSession: typeof oldSession | null;
       isPlaying: boolean;
-      eofHandled: boolean;
-      handleSpawnedProcessExit: (
-        process: ChildProcess,
-        code: number | null,
-        signal: NodeJS.Signals | null,
-        handleSuccess: () => void,
-        handleError: (error: Error) => void,
-      ) => void;
     };
     let playUrlCalls = 0;
 
-    player.mpvProcess = oldProcess;
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
+
+    player.activeSession = oldSession;
     player.isPlaying = true;
-    player.eofHandled = false;
 
     stubMethod(playerService, "play", async () => {
       throw new Error("play() should not be used when playUrl() succeeds");
@@ -306,9 +347,8 @@ describe("QueueService mix creation", () => {
 
     const tracks = await queueService.createMixFromTrack(baseTrack);
 
-    player.handleSpawnedProcessExit(oldProcess, 0, null, () => {}, () => {});
-    await Promise.resolve();
-
+    expect(killCalls).toBe(1);
+    expect(player.activeSession).toBeNull();
     expect(playUrlCalls).toBe(1);
     expect(tracks).toEqual([baseTrack, ...mixTracks]);
     expectMixTrack(queueService.getState().currentTrack!, baseTrack);
@@ -322,6 +362,9 @@ describe("QueueService mix creation", () => {
     const playerService = getPlayerService();
     const musicService = getMusicService();
     let playCalls = 0;
+
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
 
     stubMethod(playerService, "stop", async () => {});
     stubMethod(playerService, "play", async (videoId: string) => {
@@ -348,6 +391,9 @@ describe("QueueService mix creation", () => {
     const queueService = getQueueService();
     const playerService = getPlayerService();
     const musicService = getMusicService();
+
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
 
     stubMethod(playerService, "stop", async () => {});
     stubMethod(playerService, "play", async () => {

--- a/src/__tests__/player.service.test.ts
+++ b/src/__tests__/player.service.test.ts
@@ -45,6 +45,7 @@ type TestSession = {
   source: { type: "stream"; value: string };
   volumeMultiplier: number;
   targetVolume: number;
+  duration: number | null;
   process: ChildProcess;
   ipcSocket: null;
   ipcPath: string;
@@ -62,6 +63,7 @@ function createSession(process: ChildProcess): TestSession {
     source: { type: "stream" as const, value: "https://example.com/audio" },
     volumeMultiplier: 1,
     targetVolume: 70,
+    duration: null,
     process,
     ipcSocket: null,
     ipcPath: "/tmp/test-mpv.sock",
@@ -422,6 +424,44 @@ describe("PlayerService - seek functionality", () => {
       expect(settle).toHaveBeenCalledTimes(1);
       expect(settle).toHaveBeenCalledWith(true);
       expect(reject).not.toHaveBeenCalled();
+      expect(session.duration).toBe(215);
+    });
+
+    test("should retain a preloaded session duration after promotion", async () => {
+      const outgoing = createSession({
+        kill: mock(() => true),
+      } as unknown as ChildProcess);
+      const standby = {
+        ...createSession({
+          kill: mock(() => true),
+        } as unknown as ChildProcess),
+        id: 2,
+        purpose: "standby" as const,
+        trackId: "track-2",
+      };
+      const player = playerService as unknown as {
+        activeSession: typeof outgoing | null;
+        standbySession: typeof standby | null;
+        handlePropertyChange: (
+          session: typeof standby,
+          message: {
+            name: string;
+            data: number | boolean;
+          },
+        ) => void;
+      };
+
+      player.activeSession = outgoing;
+      player.standbySession = standby;
+      player.handlePropertyChange(standby, {
+        name: "duration",
+        data: 215,
+      });
+
+      const promoted = await playerService.playPreloaded("track-2");
+
+      expect(promoted).toBe(true);
+      expect(playerService.getActiveDuration()).toBe(215);
     });
 
     test("should clear playback state when session startup fails", async () => {

--- a/src/__tests__/player.service.test.ts
+++ b/src/__tests__/player.service.test.ts
@@ -33,7 +33,29 @@ function restoreMethods(): void {
   }
 }
 
-function createSession(process: ChildProcess) {
+function waitFor(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+type TestSession = {
+  id: number;
+  purpose: "active" | "standby" | "retiring";
+  source: { type: "stream"; value: string };
+  volumeMultiplier: number;
+  targetVolume: number;
+  process: ChildProcess;
+  ipcSocket: null;
+  ipcPath: string;
+  ipcConnectRetries: number;
+  eofHandled: boolean;
+  ready: boolean;
+  trackId: string;
+  confirmation: null;
+};
+
+function createSession(process: ChildProcess): TestSession {
   return {
     id: 1,
     purpose: "active" as const,
@@ -161,6 +183,70 @@ describe("PlayerService - seek functionality", () => {
 
       playerService.setVolume(100);
       expect(playerService.getVolume()).toBe(100);
+    });
+
+    test("should update standby target volume when user volume changes", () => {
+      const fakeProcess = {} as ChildProcess;
+      const standby = {
+        ...createSession(fakeProcess),
+        id: 2,
+        purpose: "standby" as const,
+        trackId: "track-2",
+        volumeMultiplier: 1.5,
+      };
+      const setVolumeSpy = mock((_session: unknown, _volume: number) => true);
+      const player = playerService as unknown as {
+        standbySession: typeof standby | null;
+        setSessionVolume: (
+          session: typeof standby,
+          volume: number,
+        ) => boolean;
+      };
+
+      stubMethod(
+        player,
+        "setSessionVolume",
+        setVolumeSpy as unknown as typeof player.setSessionVolume,
+      );
+
+      player.standbySession = standby;
+
+      playerService.setVolume(80);
+
+      expect(standby.targetVolume).toBe(120);
+      expect(setVolumeSpy).toHaveBeenCalledWith(standby, 120);
+    });
+
+    test("should update standby target volume when track multiplier changes", () => {
+      const fakeProcess = {} as ChildProcess;
+      const standby = {
+        ...createSession(fakeProcess),
+        id: 2,
+        purpose: "standby" as const,
+        trackId: "track-2",
+      };
+      const setVolumeSpy = mock((_session: unknown, _volume: number) => true);
+      const player = playerService as unknown as {
+        standbySession: typeof standby | null;
+        setSessionVolume: (
+          session: typeof standby,
+          volume: number,
+        ) => boolean;
+      };
+
+      stubMethod(
+        player,
+        "setSessionVolume",
+        setVolumeSpy as unknown as typeof player.setSessionVolume,
+      );
+
+      player.standbySession = standby;
+
+      playerService.setTrackVolumeMultiplier("track-2", 1.6);
+
+      expect(standby.volumeMultiplier).toBe(1.6);
+      expect(standby.targetVolume).toBe(112);
+      expect(setVolumeSpy).toHaveBeenCalledWith(standby, 112);
     });
   });
 
@@ -375,6 +461,177 @@ describe("PlayerService - seek functionality", () => {
       );
       expect(playerService.isCurrentlyPlaying()).toBe(false);
       expect(player.activeSession).toBeNull();
+    });
+
+    test("should restore target volume when promoting a preloaded session", async () => {
+      const outgoing = createSession({
+        kill: mock(() => true),
+      } as unknown as ChildProcess);
+      const standby = {
+        ...createSession({
+          kill: mock(() => true),
+        } as unknown as ChildProcess),
+        id: 2,
+        purpose: "standby" as const,
+        trackId: "track-2",
+        volumeMultiplier: 1.2,
+        targetVolume: 84,
+      };
+      const setPausedSpy = mock((_session: unknown, _paused: boolean) => true);
+      const setVolumeSpy = mock((_session: unknown, _volume: number) => true);
+      const player = playerService as unknown as {
+        activeSession: typeof outgoing | null;
+        standbySession: typeof standby | null;
+        setSessionPaused: (
+          session: typeof standby,
+          paused: boolean,
+        ) => boolean;
+        setSessionVolume: (
+          session: typeof standby,
+          volume: number,
+        ) => boolean;
+      };
+
+      stubMethod(
+        player,
+        "setSessionPaused",
+        setPausedSpy as unknown as typeof player.setSessionPaused,
+      );
+      stubMethod(
+        player,
+        "setSessionVolume",
+        setVolumeSpy as unknown as typeof player.setSessionVolume,
+      );
+
+      player.activeSession = outgoing;
+      player.standbySession = standby;
+
+      const promoted = await playerService.playPreloaded("track-2");
+
+      expect(promoted).toBe(true);
+      expect(player.activeSession).toBe(standby);
+      expect(player.standbySession).toBeNull();
+      expect(standby.targetVolume).toBe(84);
+      expect(setPausedSpy).toHaveBeenCalledWith(standby, false);
+      expect(setVolumeSpy).toHaveBeenCalledWith(standby, standby.targetVolume);
+    });
+
+    test("should finalize crossfade with the incoming target volume", async () => {
+      const outgoing = createSession({
+        kill: mock(() => true),
+      } as unknown as ChildProcess);
+      const incoming = {
+        ...createSession({
+          kill: mock(() => true),
+        } as unknown as ChildProcess),
+        id: 2,
+        purpose: "standby" as const,
+        trackId: "track-2",
+        volumeMultiplier: 92 / 70,
+        targetVolume: 92,
+      };
+      const setPausedSpy = mock((_session: unknown, _paused: boolean) => true);
+      const setVolumeSpy = mock((_session: unknown, _volume: number) => true);
+      const player = playerService as unknown as {
+        activeSession: typeof outgoing | null;
+        standbySession: typeof incoming | null;
+        setSessionPaused: (
+          session: typeof incoming,
+          paused: boolean,
+        ) => boolean;
+        setSessionVolume: (
+          session: typeof incoming | typeof outgoing,
+          volume: number,
+        ) => boolean;
+      };
+
+      stubMethod(
+        player,
+        "setSessionPaused",
+        setPausedSpy as unknown as typeof player.setSessionPaused,
+      );
+      stubMethod(
+        player,
+        "setSessionVolume",
+        setVolumeSpy as unknown as typeof player.setSessionVolume,
+      );
+
+      player.activeSession = outgoing;
+      player.standbySession = incoming;
+
+      const didStart = await playerService.crossfadeToPreloaded("track-2", 100);
+      await waitFor(160);
+
+      expect(didStart).toBe(true);
+      expect(player.activeSession).toBe(incoming);
+      expect(incoming.targetVolume).toBeCloseTo(92, 10);
+      expect(setPausedSpy).toHaveBeenCalledWith(incoming, false);
+      expect(setVolumeSpy).toHaveBeenCalledWith(incoming, 0);
+      expect(
+        setVolumeSpy.mock.calls.some(
+          ([session, volume]) =>
+            session === incoming &&
+            typeof volume === "number" &&
+            Math.abs(volume - incoming.targetVolume) < 1e-6,
+        ),
+      ).toBe(true);
+      expect(setVolumeSpy).toHaveBeenCalledWith(outgoing, 0);
+    });
+
+    test("should restore the active target volume when crossfade is interrupted", () => {
+      const outgoing = {
+        ...createSession({
+          kill: mock(() => true),
+        } as unknown as ChildProcess),
+        id: 1,
+        purpose: "retiring" as const,
+        trackId: "track-1",
+      };
+      const incoming = {
+        ...createSession({
+          kill: mock(() => true),
+        } as unknown as ChildProcess),
+        id: 2,
+        trackId: "track-2",
+        targetVolume: 96,
+      };
+      const setVolumeSpy = mock((_session: unknown, _volume: number) => true);
+      const player = playerService as unknown as {
+        activeSession: typeof incoming | null;
+        retiringSessions: Set<typeof outgoing>;
+        crossfadeTimer: ReturnType<typeof setInterval> | null;
+        setSessionVolume: (
+          session: typeof incoming,
+          volume: number,
+        ) => boolean;
+        stopSpecificSession: (session: typeof outgoing | null) => void;
+        finalizeCrossfadeInterruption: () => void;
+      };
+
+      stubMethod(
+        player,
+        "setSessionVolume",
+        setVolumeSpy as unknown as typeof player.setSessionVolume,
+      );
+      stubMethod(
+        player,
+        "stopSpecificSession",
+        ((session: typeof outgoing | null) => {
+          if (session) {
+            player.retiringSessions.delete(session);
+          }
+        }) as typeof player.stopSpecificSession,
+      );
+
+      player.activeSession = incoming;
+      player.retiringSessions = new Set([outgoing]);
+      player.crossfadeTimer = setInterval(() => {}, 1000);
+
+      player.finalizeCrossfadeInterruption();
+
+      expect(setVolumeSpy).toHaveBeenCalledWith(incoming, 96);
+      expect(player.retiringSessions.size).toBe(0);
+      expect(player.crossfadeTimer).toBeNull();
     });
   });
 });

--- a/src/__tests__/queue.autoplay.test.ts
+++ b/src/__tests__/queue.autoplay.test.ts
@@ -41,6 +41,39 @@ function restoreMethods(): void {
   }
 }
 
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 200,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for autoplay to reach the expected state");
+    }
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+}
+
+function suppressNextTrackPreload(
+  queueService: ReturnType<typeof getQueueService>,
+): void {
+  const queue = queueService as unknown as {
+    syncNextTrackPreload: (options?: { force?: boolean }) => Promise<boolean>;
+  };
+
+  stubMethod(queue, "syncNextTrackPreload", async () => false);
+}
+
+function stubTrackLoudness(
+  musicService: ReturnType<typeof getMusicService>,
+): void {
+  stubMethod(musicService, "getTrackLoudness", async () => null);
+}
+
 const searchedTrack: Track = {
   videoId: "search-track",
   title: "Search Song",
@@ -80,6 +113,9 @@ describe("QueueService autoplay after adding a searched track", () => {
       trackReadyEvents.push(track);
     });
 
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
+
     stubMethod(playerService, "isCurrentlyPlaying", () => false);
     stubMethod(playerService, "stop", async () => {});
     stubMethod(playerService, "play", async () => {
@@ -106,8 +142,7 @@ describe("QueueService autoplay after adding a searched track", () => {
       addResolved = true;
     });
 
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForCondition(() => resolvePlaybackStart !== null);
 
     expect(addResolved).toBe(false);
     expect(queueService.getState().currentTrack?.videoId).toBe(
@@ -163,6 +198,9 @@ describe("QueueService autoplay after adding a searched track", () => {
     queueService.onPlayError((payload) => {
       playErrors.push(payload);
     });
+
+    suppressNextTrackPreload(queueService);
+    stubTrackLoudness(musicService);
 
     stubMethod(playerService, "isCurrentlyPlaying", () => false);
     stubMethod(playerService, "stop", async () => {});

--- a/src/__tests__/queue.service.test.ts
+++ b/src/__tests__/queue.service.test.ts
@@ -116,6 +116,140 @@ describe("QueueService - seekTo functionality", () => {
       // Position should be clamped to duration (which is 0 by default)
       expect(state.position).toBeLessThanOrEqual(state.duration);
     });
+
+    test("should not clamp seek requests to zero when duration is unknown", () => {
+      const seekSpy = mock((_position: number) => {});
+      const playerService = getPlayerService();
+      const internalQueueService = queueService as unknown as {
+        currentTrack: Track | null;
+        currentDuration: number;
+      };
+
+      stubMethod(playerService, "seek", seekSpy as typeof playerService.seek);
+      internalQueueService.currentTrack = {
+        ...track("track-unknown", "Unknown Duration Track"),
+        duration: 0,
+      };
+      internalQueueService.currentDuration = 0;
+
+      queueService.seekTo(42);
+
+      expect(seekSpy).toHaveBeenCalledWith(42);
+      expect(queueService.getState().position).toBe(42);
+    });
+  });
+
+  describe("preloaded duration recovery", () => {
+    test("should restore duration from the promoted preloaded session", async () => {
+      const nextTrack = {
+        ...track("next-track", "Next Track"),
+        duration: 0,
+      };
+      const playerService = getPlayerService();
+      const internalQueueService = queueService as unknown as {
+        queue: Track[];
+        currentTrack: Track | null;
+        syncNextTrackPreload: (options?: { force?: boolean }) => Promise<boolean>;
+        fetchAndBroadcastLyrics: () => void;
+        maybeHydrateRadioQueue: () => void;
+      };
+
+      stubMethod(
+        playerService,
+        "isTrackPreloaded",
+        (() => true) as typeof playerService.isTrackPreloaded,
+      );
+      stubMethod(
+        playerService,
+        "playPreloaded",
+        (async () => true) as typeof playerService.playPreloaded,
+      );
+      stubMethod(
+        playerService,
+        "getActiveDuration",
+        (() => 215) as typeof playerService.getActiveDuration,
+      );
+      stubMethod(
+        internalQueueService,
+        "syncNextTrackPreload",
+        (async () => false) as typeof internalQueueService.syncNextTrackPreload,
+      );
+      stubMethod(
+        internalQueueService,
+        "fetchAndBroadcastLyrics",
+        (() => {}) as typeof internalQueueService.fetchAndBroadcastLyrics,
+      );
+      stubMethod(
+        internalQueueService,
+        "maybeHydrateRadioQueue",
+        (() => {}) as typeof internalQueueService.maybeHydrateRadioQueue,
+      );
+
+      internalQueueService.currentTrack = null;
+      internalQueueService.queue = [nextTrack];
+
+      await queueService.playNext();
+
+      expect(queueService.getState().currentTrack?.videoId).toBe(nextTrack.videoId);
+      expect(queueService.getState().duration).toBe(215);
+    });
+
+    test("should restore duration from the promoted session during crossfade", async () => {
+      const currentTrack = track("current-track", "Current Track");
+      const nextTrack = {
+        ...track("next-track", "Next Track"),
+        duration: 0,
+      };
+      const playerService = getPlayerService();
+      const internalQueueService = queueService as unknown as {
+        queue: Track[];
+        currentTrack: Track | null;
+        preloadPromise: Promise<boolean> | null;
+        preloadTrackId: string | null;
+        crossfadeStartedForTrackId: string | null;
+        syncNextTrackPreload: (options?: { force?: boolean }) => Promise<boolean>;
+        fetchAndBroadcastLyrics: () => void;
+        maybeHydrateRadioQueue: () => void;
+        startCrossfadeToNextTrack: (track: Track) => Promise<void>;
+      };
+
+      stubMethod(
+        playerService,
+        "crossfadeToPreloaded",
+        (async () => true) as typeof playerService.crossfadeToPreloaded,
+      );
+      stubMethod(
+        playerService,
+        "getActiveDuration",
+        (() => 215) as typeof playerService.getActiveDuration,
+      );
+      stubMethod(
+        internalQueueService,
+        "syncNextTrackPreload",
+        (async () => false) as typeof internalQueueService.syncNextTrackPreload,
+      );
+      stubMethod(
+        internalQueueService,
+        "fetchAndBroadcastLyrics",
+        (() => {}) as typeof internalQueueService.fetchAndBroadcastLyrics,
+      );
+      stubMethod(
+        internalQueueService,
+        "maybeHydrateRadioQueue",
+        (() => {}) as typeof internalQueueService.maybeHydrateRadioQueue,
+      );
+
+      internalQueueService.currentTrack = currentTrack;
+      internalQueueService.queue = [nextTrack];
+      internalQueueService.preloadPromise = null;
+      internalQueueService.preloadTrackId = nextTrack.videoId;
+      internalQueueService.crossfadeStartedForTrackId = currentTrack.videoId;
+
+      await internalQueueService.startCrossfadeToNextTrack(nextTrack);
+
+      expect(queueService.getState().currentTrack?.videoId).toBe(nextTrack.videoId);
+      expect(queueService.getState().duration).toBe(215);
+    });
   });
 
   describe("volume control", () => {

--- a/src/__tests__/queue.service.test.ts
+++ b/src/__tests__/queue.service.test.ts
@@ -1,12 +1,42 @@
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   __resetQueueServiceForTests,
   getQueueService,
 } from "../services/queue.service.ts";
 import {
   __resetPlayerServiceForTests,
+  getPlayerService,
 } from "../services/player.service.ts";
+import { getMusicService } from "../services/music.service.ts";
 import type { Track } from "../types/index.ts";
+
+type RestorableMethod = {
+  target: Record<string, unknown>;
+  key: string;
+  original: unknown;
+};
+
+const restores: RestorableMethod[] = [];
+
+function stubMethod<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  replacement: T[K],
+): void {
+  restores.push({
+    target: target as Record<string, unknown>,
+    key: key as string,
+    original: target[key],
+  });
+  target[key] = replacement;
+}
+
+function restoreMethods(): void {
+  while (restores.length > 0) {
+    const restore = restores.pop()!;
+    restore.target[restore.key] = restore.original;
+  }
+}
 
 const track = (videoId: string, title: string): Track => ({
   videoId,
@@ -19,9 +49,14 @@ describe("QueueService - seekTo functionality", () => {
   let queueService: ReturnType<typeof getQueueService>;
 
   beforeEach(() => {
+    restoreMethods();
     __resetQueueServiceForTests();
     __resetPlayerServiceForTests();
     queueService = getQueueService();
+  });
+
+  afterEach(() => {
+    restoreMethods();
   });
 
   describe("seekTo() method - input validation", () => {
@@ -111,6 +146,133 @@ describe("QueueService - seekTo functionality", () => {
         volumeNormalizationEnabled: true,
       });
       expect(queueService.getState().playbackSettings).toEqual(nextSettings);
+    });
+
+    test("should resync the current and next track when volume normalization changes", () => {
+      const currentTrack = track("current-track", "Current Track");
+      const nextTrack = track("next-track", "Next Track");
+      const syncTrackSpy = mock(async (_track: Track | null) => {});
+      const syncPreloadSpy = mock(async (_options?: { force?: boolean }) => false);
+      const internalQueueService = queueService as unknown as {
+        currentTrack: Track | null;
+        queue: Track[];
+        syncTrackVolumeNormalization: (track: Track | null) => Promise<void>;
+        syncNextTrackPreload: (options?: { force?: boolean }) => Promise<boolean>;
+      };
+
+      stubMethod(
+        internalQueueService,
+        "syncTrackVolumeNormalization",
+        syncTrackSpy as unknown as typeof internalQueueService.syncTrackVolumeNormalization,
+      );
+      stubMethod(
+        internalQueueService,
+        "syncNextTrackPreload",
+        syncPreloadSpy as unknown as typeof internalQueueService.syncNextTrackPreload,
+      );
+
+      internalQueueService.currentTrack = currentTrack;
+      internalQueueService.queue = [nextTrack];
+
+      queueService.setPlaybackSettings({
+        volumeNormalizationEnabled: false,
+      });
+
+      expect(syncTrackSpy).toHaveBeenCalledTimes(2);
+      expect(syncTrackSpy.mock.calls[0]?.[0]).toBe(currentTrack);
+      expect(syncTrackSpy.mock.calls[1]?.[0]).toBe(nextTrack);
+      expect(syncPreloadSpy).toHaveBeenCalledWith({ force: true });
+    });
+
+    test("should prefer perceptual loudness metadata when resolving volume normalization", async () => {
+      const musicService = getMusicService() as unknown as {
+        getTrackLoudness: (videoId: string) => Promise<{
+          loudnessDb?: number;
+          perceptualLoudnessDb?: number;
+        } | null>;
+      };
+      const internalQueueService = queueService as unknown as {
+        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
+      };
+
+      stubMethod(
+        musicService,
+        "getTrackLoudness",
+        (async () => ({
+          loudnessDb: -3,
+          perceptualLoudnessDb: -18,
+        })) as typeof musicService.getTrackLoudness,
+      );
+
+      const volumeMultiplier =
+        await internalQueueService.resolveTrackVolumeMultiplier(
+          track("track-perceptual", "Perceptual Track"),
+        );
+
+      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, 4 / 20), 5);
+    });
+
+    test("should use a conservative loudnessDb fallback without boosting", async () => {
+      const musicService = getMusicService() as unknown as {
+        getTrackLoudness: (videoId: string) => Promise<{
+          loudnessDb?: number;
+          perceptualLoudnessDb?: number;
+        } | null>;
+      };
+      const internalQueueService = queueService as unknown as {
+        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
+      };
+
+      stubMethod(
+        musicService,
+        "getTrackLoudness",
+        (async () => ({
+          loudnessDb: -8,
+        })) as typeof musicService.getTrackLoudness,
+      );
+
+      const volumeMultiplier =
+        await internalQueueService.resolveTrackVolumeMultiplier(
+          track("track-fallback", "Fallback Track"),
+        );
+
+      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, -8 / 20), 5);
+      expect(volumeMultiplier).toBeLessThan(1);
+    });
+
+    test("should clamp normalization boost and attenuation boundaries", async () => {
+      const loudnessSamples = [
+        { perceptualLoudnessDb: -30 },
+        { perceptualLoudnessDb: 10 },
+      ];
+      const musicService = getMusicService() as unknown as {
+        getTrackLoudness: (videoId: string) => Promise<{
+          loudnessDb?: number;
+          perceptualLoudnessDb?: number;
+        } | null>;
+      };
+      const internalQueueService = queueService as unknown as {
+        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
+      };
+      let callIndex = 0;
+
+      stubMethod(
+        musicService,
+        "getTrackLoudness",
+        (async () => loudnessSamples[callIndex++] ?? null) as typeof musicService.getTrackLoudness,
+      );
+
+      const boostedMultiplier =
+        await internalQueueService.resolveTrackVolumeMultiplier(
+          track("track-boost", "Boosted Track"),
+        );
+      const attenuatedMultiplier =
+        await internalQueueService.resolveTrackVolumeMultiplier(
+          track("track-attenuate", "Attenuated Track"),
+        );
+
+      expect(boostedMultiplier).toBeCloseTo(Math.pow(10, 6 / 20), 5);
+      expect(attenuatedMultiplier).toBeCloseTo(Math.pow(10, -12 / 20), 5);
     });
   });
 

--- a/src/__tests__/release-notes.service.test.ts
+++ b/src/__tests__/release-notes.service.test.ts
@@ -91,7 +91,7 @@ describe("ReleaseNotesService", () => {
     expect(response.source).toBe("fallback");
     expect(response.currentRelease?.version).toBe("0.7.0");
     expect(response.releases.map((entry) => entry.version)).toContain("0.7.0");
-    expect(response.releases[0]?.version).toBe("0.7.6");
+    expect(response.releases[0]?.version).toBe("0.7.7");
     expect(
       response.warnings.some((warning) => warning.includes("已改用本機版本說明")),
     ).toBe(true);

--- a/src/data/release-notes.ts
+++ b/src/data/release-notes.ts
@@ -3,11 +3,11 @@ import type { ReleaseNotesEntry } from "../types/index.ts";
 const fallbackReleaseNotesByVersion: Record<string, ReleaseNotesEntry> = {
   "0.7.7": {
     version: "0.7.7",
-    title: "音量播放修正",
+    title: "音量播放與 Discover 修正",
     publishedAt: "2026-03-29",
     status: "preview",
     summary:
-      "修正切歌偶發靜音，並重新校準音量平衡對 YouTube loudness metadata 的換算與同步時機。",
+      "修正切歌偶發靜音、重新校準音量平衡換算，並補正 Discover 本站排名歌曲長度偶發顯示 0:00 的問題。",
     sections: [
       {
         category: "fixed",
@@ -31,6 +31,14 @@ const fallbackReleaseNotesByVersion: Record<string, ReleaseNotesEntry> = {
         description: "把這次修正轉成可重複驗證的測試，降低再次發生的機率。",
         items: [
           "補上播放器音量同步與版本說明的 regression tests，降低後續再發機率。",
+        ],
+      },
+      {
+        category: "fixed",
+        title: "Discover 排行資料補正",
+        description: "避免本站排名沿用錯誤的歌曲 metadata，造成時長顯示異常。",
+        items: [
+          "修正本站排名歌曲長度被 0 覆蓋後持續顯示 0:00 的問題，並在榜單讀取時自動回填缺失 metadata。",
         ],
       },
     ],

--- a/src/data/release-notes.ts
+++ b/src/data/release-notes.ts
@@ -39,7 +39,7 @@ const fallbackReleaseNotesByVersion: Record<string, ReleaseNotesEntry> = {
     version: "0.7.6",
     title: "Discover 體驗定稿與播放增強",
     publishedAt: "2026-03-28",
-    status: "preview",
+    status: "released",
     summary:
       "把 Discover 補成更完整的探索入口，加入音樂影片焦點展示、榜單化熱門點播，以及更聰明的自動 Mix 與播放調整。",
     sections: [
@@ -80,7 +80,7 @@ const fallbackReleaseNotesByVersion: Record<string, ReleaseNotesEntry> = {
     version: "0.7.0",
     title: "Discover 多市場探索",
     publishedAt: "2026-03-28",
-    status: "preview",
+    status: "released",
     summary: "把探索體驗從搜尋頁獨立出來，改成可切換 8 個市場的 Discover 首頁。",
     sections: [
       {

--- a/src/data/release-notes.ts
+++ b/src/data/release-notes.ts
@@ -1,6 +1,40 @@
 import type { ReleaseNotesEntry } from "../types/index.ts";
 
 const fallbackReleaseNotesByVersion: Record<string, ReleaseNotesEntry> = {
+  "0.7.7": {
+    version: "0.7.7",
+    title: "音量播放修正",
+    publishedAt: "2026-03-29",
+    status: "preview",
+    summary:
+      "修正切歌偶發靜音，並重新校準音量平衡對 YouTube loudness metadata 的換算與同步時機。",
+    sections: [
+      {
+        category: "fixed",
+        title: "播放穩定性修復",
+        description: "優先處理直接影響切歌可用性的 regression。",
+        items: [
+          "修正切到下一首時偶發無聲，避免預載與 Crossfade 轉場遺失目標音量。",
+        ],
+      },
+      {
+        category: "changed",
+        title: "音量平衡調整",
+        description: "讓音量平衡改用更穩定、可預期的 metadata 解讀與同步流程。",
+        items: [
+          "修正音量平衡對 YouTube loudness metadata 的換算與套用時機，讓不同歌曲的體感音量更一致。",
+        ],
+      },
+      {
+        category: "fixed",
+        title: "回歸驗證補強",
+        description: "把這次修正轉成可重複驗證的測試，降低再次發生的機率。",
+        items: [
+          "補上播放器音量同步與版本說明的 regression tests，降低後續再發機率。",
+        ],
+      },
+    ],
+  },
   "0.7.6": {
     version: "0.7.6",
     title: "Discover 體驗定稿與播放增強",

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -901,12 +901,12 @@ api.get("/system/release-notes", async (c) => {
  * GET /api/discover/markets
  * 取得可用市場與本站熱門點播
  */
-api.get("/discover/markets", (c) => {
+api.get("/discover/markets", async (c) => {
   try {
     const discoverService = getDiscoverService();
     return c.json<ApiResponse>({
       success: true,
-      data: discoverService.getMarketsResponse(),
+      data: await discoverService.getMarketsResponse(),
     });
   } catch (error) {
     console.error("Failed to get discover markets:", error);

--- a/src/services/discover.service.ts
+++ b/src/services/discover.service.ts
@@ -85,6 +85,11 @@ type TrackActivityRow = {
 };
 
 type JoinedTopRequestedRow = TrackCatalogRow & TrackActivityRow;
+type TrackCatalogMetadataUpdate = {
+  videoId: string;
+  artist?: string;
+  duration?: number;
+};
 
 const DISCOVER_MARKET_CONFIGS: readonly DiscoverMarketConfig[] = [
   { code: "TW", label: "台灣", lang: "zh-TW", location: "TW" },
@@ -129,6 +134,14 @@ function normalizeTrackForStats(track: Track): Track | null {
     thumbnail: track.thumbnail?.trim() || undefined,
     album: track.album,
   };
+}
+
+function normalizeStatsDuration(value: number | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  return Math.round(value);
 }
 
 function normalizeDiscoverMarketCode(
@@ -977,10 +990,22 @@ class DiscoverStatsStore {
             )
             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
             ON CONFLICT(video_id) DO UPDATE SET
-              title = excluded.title,
-              artist = excluded.artist,
-              thumbnail = excluded.thumbnail,
-              duration = excluded.duration,
+              title = CASE
+                WHEN excluded.title IS NOT NULL AND excluded.title <> 'Unknown'
+                  THEN excluded.title
+                ELSE discover_track_catalog.title
+              END,
+              artist = CASE
+                WHEN excluded.artist IS NOT NULL AND excluded.artist <> 'Unknown'
+                  THEN excluded.artist
+                ELSE discover_track_catalog.artist
+              END,
+              thumbnail = COALESCE(excluded.thumbnail, discover_track_catalog.thumbnail),
+              duration = CASE
+                WHEN excluded.duration IS NOT NULL AND excluded.duration > 0
+                  THEN excluded.duration
+                ELSE discover_track_catalog.duration
+              END,
               updated_at = excluded.updated_at
           `)
           .run(
@@ -1007,6 +1032,39 @@ class DiscoverStatsStore {
     });
 
     transaction(normalizedTracks);
+  }
+
+  updateTrackCatalogMetadata(update: TrackCatalogMetadataUpdate): void {
+    const videoId = update.videoId.trim();
+    if (!videoId) {
+      return;
+    }
+
+    const artist = hasMeaningfulArtistName(update.artist)
+      ? update.artist!.trim()
+      : null;
+    const duration = normalizeStatsDuration(update.duration);
+
+    if (!artist && duration === null) {
+      return;
+    }
+
+    this.db
+      .query(`
+        UPDATE discover_track_catalog
+        SET
+          artist = CASE
+            WHEN ?2 IS NOT NULL THEN ?2
+            ELSE artist
+          END,
+          duration = CASE
+            WHEN ?3 IS NOT NULL THEN ?3
+            ELSE duration
+          END,
+          updated_at = ?4
+        WHERE video_id = ?1
+      `)
+      .run(videoId, artist, duration, new Date().toISOString());
   }
 
   getTopRequested(limit: number = DEFAULT_TOP_REQUESTED_LIMIT): TopRequestedEntry[] {
@@ -1087,11 +1145,15 @@ export class DiscoverService {
     DiscoverService.instance = undefined;
   }
 
-  getMarketsResponse(): DiscoverMarketsResponse {
+  async getMarketsResponse(): Promise<DiscoverMarketsResponse> {
+    const topRequested = await this.enrichTopRequestedMetadata(
+      this.statsStore.getTopRequested(),
+    );
+
     return {
       markets: DISCOVER_MARKETS.map((market) => ({ ...market })),
       defaultMarket: DEFAULT_DISCOVER_MARKET,
-      topRequested: this.statsStore.getTopRequested(),
+      topRequested,
     };
   }
 
@@ -1101,6 +1163,74 @@ export class DiscoverService {
 
   recordTrackRequests(tracks: Track[]): void {
     this.statsStore.recordTrackRequests(tracks);
+  }
+
+  private async enrichTopRequestedMetadata(
+    entries: TopRequestedEntry[],
+  ): Promise<TopRequestedEntry[]> {
+    const pendingEntries = entries.filter(
+      (entry) =>
+        entry.track.duration <= 0 ||
+        !hasMeaningfulArtistName(entry.track.artist),
+    );
+
+    if (pendingEntries.length === 0) {
+      return entries;
+    }
+
+    const metadataByVideoId = new Map<string, DiscoverVideoMetadata>();
+    const metadataResults = await Promise.all(
+      pendingEntries.map(async (entry) => ({
+        videoId: entry.track.videoId,
+        metadata: await this.getDiscoverVideoMetadata(
+          DEFAULT_DISCOVER_MARKET,
+          entry.track.videoId,
+        ),
+      })),
+    );
+
+    for (const result of metadataResults) {
+      if (result.metadata) {
+        metadataByVideoId.set(result.videoId, result.metadata);
+      }
+    }
+
+    return entries.map((entry) => {
+      const metadata = metadataByVideoId.get(entry.track.videoId);
+      if (!metadata) {
+        return entry;
+      }
+
+      const resolvedDuration =
+        entry.track.duration > 0
+          ? entry.track.duration
+          : metadata.duration || 0;
+      const resolvedArtist = hasMeaningfulArtistName(entry.track.artist)
+        ? entry.track.artist
+        : metadata.artist || entry.track.artist;
+
+      if (
+        resolvedDuration === entry.track.duration &&
+        resolvedArtist === entry.track.artist
+      ) {
+        return entry;
+      }
+
+      this.statsStore.updateTrackCatalogMetadata({
+        videoId: entry.track.videoId,
+        duration: resolvedDuration,
+        artist: resolvedArtist,
+      });
+
+      return {
+        ...entry,
+        track: {
+          ...entry.track,
+          duration: resolvedDuration,
+          artist: resolvedArtist,
+        },
+      };
+    });
   }
 
   async getFeed(

--- a/src/services/player.service.ts
+++ b/src/services/player.service.ts
@@ -30,6 +30,7 @@ type PlayerSession = {
   source: SessionSource;
   volumeMultiplier: number;
   targetVolume: number;
+  duration: number | null;
   process: ChildProcess;
   ipcSocket: Socket | null;
   ipcPath: string;
@@ -556,6 +557,15 @@ class PlayerService {
     session: PlayerSession,
     message: { name: string; data: number | boolean },
   ): void {
+    if (
+      message.name === "duration" &&
+      typeof message.data === "number" &&
+      Number.isFinite(message.data) &&
+      message.data >= 0
+    ) {
+      session.duration = message.data;
+    }
+
     if (message.name === "time-pos") {
       if (
         session.confirmation?.mode === "playback" &&
@@ -666,6 +676,7 @@ class PlayerService {
       source: options.source,
       volumeMultiplier: this.normalizeVolumeMultiplier(options.volumeMultiplier),
       targetVolume: 0,
+      duration: null,
       process: null as unknown as ChildProcess,
       ipcSocket: null,
       ipcPath: this.getIpcPath(sessionId),
@@ -1340,6 +1351,10 @@ class PlayerService {
 
   getVolume(): number {
     return this.currentVolume;
+  }
+
+  getActiveDuration(): number | null {
+    return this.activeSession?.duration ?? null;
   }
 
   isCurrentlyPlaying(): boolean {

--- a/src/services/player.service.ts
+++ b/src/services/player.service.ts
@@ -42,6 +42,7 @@ type PlayerSession = {
 
 const CROSSFADE_TICK_MS = 100;
 const RETIRING_STOP_GRACE_MS = 180;
+const SESSION_VOLUME_RETRY_DELAY_MS = 120;
 const MAX_USER_VOLUME = 100;
 const MAX_SESSION_VOLUME = 200;
 
@@ -59,6 +60,7 @@ class PlayerService {
   private eventCallback: PlayerEventCallback | null = null;
   private playSessionId = 0;
   private crossfadeTimer: ReturnType<typeof setInterval> | null = null;
+  private crossfadeFinalizeTimeout: ReturnType<typeof setTimeout> | null = null;
   private retiringStopTimeouts = new Map<number, ReturnType<typeof setTimeout>>();
 
   private constructor() {
@@ -220,6 +222,13 @@ class PlayerService {
     }
   }
 
+  private clearCrossfadeFinalizeTimeout(): void {
+    if (this.crossfadeFinalizeTimeout) {
+      clearTimeout(this.crossfadeFinalizeTimeout);
+      this.crossfadeFinalizeTimeout = null;
+    }
+  }
+
   private clearRetiringStopTimeout(sessionId: number): void {
     const timeout = this.retiringStopTimeouts.get(sessionId);
     if (!timeout) {
@@ -310,25 +319,96 @@ class PlayerService {
     return true;
   }
 
-  private sendIpcCommand(session: PlayerSession, command: unknown[]): void {
+  private sendIpcCommand(session: PlayerSession, command: unknown[]): boolean {
     if (!session.ipcSocket || session.ipcSocket.destroyed) {
       log.debug("Cannot send IPC command: socket not connected", {
         sessionId: session.id,
         purpose: session.purpose,
       });
-      return;
+      return false;
     }
 
     session.ipcSocket.write(`${JSON.stringify({ command })}\n`);
+    return true;
   }
 
-  private setSessionPaused(session: PlayerSession, paused: boolean): void {
-    this.sendIpcCommand(session, ["set_property", "pause", paused]);
+  private setSessionPaused(session: PlayerSession, paused: boolean): boolean {
+    return this.sendIpcCommand(session, ["set_property", "pause", paused]);
   }
 
-  private setSessionVolume(session: PlayerSession, volume: number): void {
+  private setSessionVolume(session: PlayerSession, volume: number): boolean {
     const nextVolume = this.clampSessionVolume(volume);
-    this.sendIpcCommand(session, ["set_property", "volume", nextVolume]);
+    return this.sendIpcCommand(session, ["set_property", "volume", nextVolume]);
+  }
+
+  private ensureSessionTargetVolume(
+    session: PlayerSession,
+    options: {
+      onlyWhenActive?: boolean;
+      onlyWhenNoCrossfade?: boolean;
+      retryDelayMs?: number;
+    } = {},
+  ): void {
+    const applyTargetVolume = () => {
+      if (!this.isTrackedSession(session)) {
+        return;
+      }
+
+      if (options.onlyWhenActive && this.activeSession !== session) {
+        return;
+      }
+
+      if (options.onlyWhenNoCrossfade && this.crossfadeTimer) {
+        return;
+      }
+
+      this.setSessionVolume(session, session.targetVolume);
+    };
+
+    applyTargetVolume();
+    setTimeout(
+      applyTargetVolume,
+      options.retryDelayMs ?? SESSION_VOLUME_RETRY_DELAY_MS,
+    );
+  }
+
+  private promoteStandbyToActive(
+    trackId: string,
+  ): { incoming: PlayerSession; outgoing: PlayerSession | null } | null {
+    const standby = this.standbySession;
+    if (!standby || !standby.ready || standby.trackId !== trackId) {
+      return null;
+    }
+
+    const outgoing = this.activeSession;
+    this.clearCrossfadeTimer();
+    this.clearCrossfadeFinalizeTimeout();
+    this.refreshSessionTargetVolume(standby);
+    this.standbySession = null;
+    this.activeSession = standby;
+    standby.purpose = "active";
+
+    return {
+      incoming: standby,
+      outgoing,
+    };
+  }
+
+  private finalizeCrossfadeVolumes(
+    outgoing: PlayerSession,
+    incoming: PlayerSession,
+  ): void {
+    if (this.activeSession !== incoming) {
+      return;
+    }
+
+    this.clearCrossfadeTimer();
+    this.clearCrossfadeFinalizeTimeout();
+    this.setSessionVolume(outgoing, 0);
+    this.ensureSessionTargetVolume(incoming, {
+      onlyWhenActive: true,
+      onlyWhenNoCrossfade: true,
+    });
   }
 
   private connectSessionIpc(session: PlayerSession): Promise<void> {
@@ -606,7 +686,7 @@ class PlayerService {
       session.volumeMultiplier,
     );
     const mpvArgs = this.buildMpvArgs(session, {
-      volume: startPaused ? 0 : session.targetVolume,
+      volume: session.targetVolume,
       startPaused,
     });
     const mpvCommand = getMpvExecutable();
@@ -852,6 +932,7 @@ class PlayerService {
 
   private stopAllSessions(): void {
     this.clearCrossfadeTimer();
+    this.clearCrossfadeFinalizeTimeout();
     this.clearAllRetiringStopTimeouts();
     this.stopSpecificSession(this.activeSession);
     this.stopSpecificSession(this.standbySession);
@@ -880,12 +961,16 @@ class PlayerService {
     }
 
     this.clearCrossfadeTimer();
+    this.clearCrossfadeFinalizeTimeout();
     for (const session of [...this.retiringSessions]) {
       this.stopSpecificSession(session);
     }
 
     if (this.activeSession) {
-      this.setSessionVolume(this.activeSession, this.activeSession.targetVolume);
+      this.ensureSessionTargetVolume(this.activeSession, {
+        onlyWhenActive: true,
+        onlyWhenNoCrossfade: true,
+      });
     }
   }
 
@@ -926,6 +1011,13 @@ class PlayerService {
         }
         this.isPlaying = false;
         throw new Error("Playback session was cancelled before start");
+      }
+
+      if (this.activeSession === session) {
+        this.ensureSessionTargetVolume(session, {
+          onlyWhenActive: true,
+          onlyWhenNoCrossfade: true,
+        });
       }
     } catch (error) {
       if (this.activeSession === session) {
@@ -989,6 +1081,7 @@ class PlayerService {
         options.volumeMultiplier,
       );
       this.refreshSessionTargetVolume(this.standbySession);
+      this.ensureSessionTargetVolume(this.standbySession);
       return true;
     }
 
@@ -1001,7 +1094,6 @@ class PlayerService {
       purpose: "standby",
       confirmMode: "preload",
       startPaused: true,
-      volume: 0,
       volumeMultiplier: options.volumeMultiplier,
       trackId,
     });
@@ -1010,6 +1102,14 @@ class PlayerService {
 
     try {
       const isReady = await ready;
+      if (
+        isReady &&
+        this.standbySession === session &&
+        session.ready &&
+        session.trackId === trackId
+      ) {
+        this.ensureSessionTargetVolume(session);
+      }
       return Boolean(
         isReady &&
           this.standbySession === session &&
@@ -1049,19 +1149,17 @@ class PlayerService {
   }
 
   async playPreloaded(trackId: string): Promise<boolean> {
-    const standby = this.standbySession;
-    if (!standby || !standby.ready || standby.trackId !== trackId) {
+    const promoted = this.promoteStandbyToActive(trackId);
+    if (!promoted) {
       return false;
     }
 
-    const outgoing = this.activeSession;
-    this.standbySession = null;
-    this.activeSession = standby;
-    standby.purpose = "active";
-    this.clearCrossfadeTimer();
-
-    this.setSessionVolume(standby, standby.targetVolume);
-    this.setSessionPaused(standby, false);
+    const { incoming, outgoing } = promoted;
+    this.setSessionPaused(incoming, false);
+    this.ensureSessionTargetVolume(incoming, {
+      onlyWhenActive: true,
+      onlyWhenNoCrossfade: true,
+    });
 
     if (outgoing) {
       this.stopSpecificSession(outgoing);
@@ -1075,22 +1173,16 @@ class PlayerService {
     trackId: string,
     durationMs: number,
   ): Promise<boolean> {
-    const outgoing = this.activeSession;
-    const incoming = this.standbySession;
-
-    if (
-      !outgoing ||
-      !incoming ||
-      !incoming.ready ||
-      incoming.trackId !== trackId
-    ) {
+    if (!this.activeSession) {
       return false;
     }
 
-    this.clearCrossfadeTimer();
-    this.standbySession = null;
-    this.activeSession = incoming;
-    incoming.purpose = "active";
+    const promoted = this.promoteStandbyToActive(trackId);
+    if (!promoted?.outgoing) {
+      return false;
+    }
+
+    const { incoming, outgoing } = promoted;
     outgoing.purpose = "retiring";
     this.retiringSessions.add(outgoing);
 
@@ -1110,14 +1202,16 @@ class PlayerService {
       this.setSessionVolume(incoming, incoming.targetVolume * fadeInFactor);
 
       if (progress >= 1) {
-        this.clearCrossfadeTimer();
-        this.setSessionVolume(outgoing, 0);
-        this.setSessionVolume(incoming, incoming.targetVolume);
+        this.finalizeCrossfadeVolumes(outgoing, incoming);
       }
     };
 
     applyVolumes();
     this.crossfadeTimer = setInterval(applyVolumes, CROSSFADE_TICK_MS);
+    this.clearCrossfadeFinalizeTimeout();
+    this.crossfadeFinalizeTimeout = setTimeout(() => {
+      this.finalizeCrossfadeVolumes(outgoing, incoming);
+    }, totalDuration + CROSSFADE_TICK_MS);
     this.scheduleRetiringStop(outgoing, totalDuration);
     this.isPlaying = true;
 
@@ -1178,7 +1272,14 @@ class PlayerService {
     }
 
     if (this.activeSession && !this.crossfadeTimer) {
-      this.setSessionVolume(this.activeSession, this.activeSession.targetVolume);
+      this.ensureSessionTargetVolume(this.activeSession, {
+        onlyWhenActive: true,
+        onlyWhenNoCrossfade: true,
+      });
+    }
+
+    if (this.standbySession) {
+      this.ensureSessionTargetVolume(this.standbySession);
     }
   }
 
@@ -1190,6 +1291,7 @@ class PlayerService {
 
     const nextMultiplier = this.normalizeVolumeMultiplier(volumeMultiplier);
     let updatedActive = false;
+    let updatedStandby = false;
 
     const updateSession = (session: PlayerSession | null): boolean => {
       if (!session || session.trackId !== normalizedTrackId) {
@@ -1202,14 +1304,21 @@ class PlayerService {
     };
 
     updatedActive = updateSession(this.activeSession);
-    updateSession(this.standbySession);
+    updatedStandby = updateSession(this.standbySession);
 
     for (const session of this.retiringSessions) {
       updateSession(session);
     }
 
     if (updatedActive && this.activeSession && !this.crossfadeTimer) {
-      this.setSessionVolume(this.activeSession, this.activeSession.targetVolume);
+      this.ensureSessionTargetVolume(this.activeSession, {
+        onlyWhenActive: true,
+        onlyWhenNoCrossfade: true,
+      });
+    }
+
+    if (updatedStandby && this.standbySession) {
+      this.ensureSessionTargetVolume(this.standbySession);
     }
   }
 
@@ -1248,6 +1357,7 @@ class PlayerService {
     this.standbySession = null;
     this.retiringSessions.clear();
     this.clearCrossfadeTimer();
+    this.clearCrossfadeFinalizeTimeout();
     this.clearAllRetiringStopTimeouts();
   }
 }

--- a/src/services/queue.service.ts
+++ b/src/services/queue.service.ts
@@ -695,12 +695,13 @@ class QueueService {
     const volumeNormalizationChanged =
       this.playbackSettings.volumeNormalizationEnabled !==
       nextSettings.volumeNormalizationEnabled;
+    const nextTrack = this.queue[0] ?? null;
     this.playbackSettings = nextSettings;
     this.broadcastState();
 
     if (volumeNormalizationChanged) {
       void this.syncTrackVolumeNormalization(this.currentTrack);
-      void this.syncTrackVolumeNormalization(this.queue[0] ?? null);
+      void this.syncTrackVolumeNormalization(nextTrack);
     }
 
     void this.syncNextTrackPreload({ force: true });
@@ -1480,19 +1481,25 @@ function arePlaybackSettingsEqual(
 function resolveNormalizationGainDb(
   loudnessInfo: TrackLoudnessInfo | null,
 ): number {
-  const loudnessDb = loudnessInfo?.loudnessDb;
   const perceptualLoudnessDb = loudnessInfo?.perceptualLoudnessDb;
-  let gainDb = 0;
-
-  if (typeof loudnessDb === "number" && Number.isFinite(loudnessDb)) {
-    gainDb = -loudnessDb;
-  } else if (
+  if (
     typeof perceptualLoudnessDb === "number" &&
     Number.isFinite(perceptualLoudnessDb)
   ) {
-    gainDb = VOLUME_NORMALIZATION_REFERENCE_DB - perceptualLoudnessDb;
+    return clampNormalizationGainDb(
+      VOLUME_NORMALIZATION_REFERENCE_DB - perceptualLoudnessDb,
+    );
   }
 
+  const loudnessDb = loudnessInfo?.loudnessDb;
+  if (typeof loudnessDb === "number" && Number.isFinite(loudnessDb)) {
+    return clampNormalizationGainDb(-Math.abs(loudnessDb));
+  }
+
+  return 0;
+}
+
+function clampNormalizationGainDb(gainDb: number): number {
   return Math.max(
     -MAX_VOLUME_NORMALIZATION_ATTENUATION_DB,
     Math.min(MAX_VOLUME_NORMALIZATION_BOOST_DB, gainDb),

--- a/src/services/queue.service.ts
+++ b/src/services/queue.service.ts
@@ -275,6 +275,21 @@ class QueueService {
     }
   }
 
+  private syncCurrentDurationFromPlayer(): boolean {
+    const activeDuration = getPlayerService().getActiveDuration();
+    if (
+      typeof activeDuration !== "number" ||
+      !Number.isFinite(activeDuration) ||
+      activeDuration <= 0 ||
+      this.currentDuration === activeDuration
+    ) {
+      return false;
+    }
+
+    this.currentDuration = activeDuration;
+    return true;
+  }
+
   /**
    * 加入歌曲到播放清單
    */
@@ -533,6 +548,10 @@ class QueueService {
     this.currentDuration = nextTrack.duration;
     this.isPaused = false;
 
+    if (activatedPreloaded) {
+      this.syncCurrentDurationFromPlayer();
+    }
+
     log.info("Playing next track", { title: nextTrack.title });
 
     // 廣播變更
@@ -569,9 +588,14 @@ class QueueService {
         trackId: nextTrack.videoId,
         volumeMultiplier,
       });
+      const didSyncDuration = this.syncCurrentDurationFromPlayer();
       log.info("Playback started successfully via direct stream URL", {
         source: streamResult.source,
       });
+      if (didSyncDuration) {
+        this.broadcastState();
+        this.broadcastProgress({ force: true });
+      }
       this.broadcastTrackReady(nextTrack);
       void this.syncNextTrackPreload({ force: true });
     } catch (playError) {
@@ -588,7 +612,12 @@ class QueueService {
         await player.play(nextTrack.videoId, {
           volumeMultiplier,
         });
+        const didSyncDuration = this.syncCurrentDurationFromPlayer();
         log.info("Fallback playback started successfully via YouTube URL");
+        if (didSyncDuration) {
+          this.broadcastState();
+          this.broadcastProgress({ force: true });
+        }
         this.broadcastTrackReady(nextTrack);
         void this.syncNextTrackPreload({ force: true });
       } catch (fallbackError) {
@@ -762,7 +791,10 @@ class QueueService {
     }
 
     // 限制在當前歌曲的 duration 範圍內
-    const clampedPosition = Math.min(position, this.currentDuration);
+    const clampedPosition =
+      Number.isFinite(this.currentDuration) && this.currentDuration > 0
+        ? Math.min(position, this.currentDuration)
+        : position;
 
     log.debug("Seeking to position", { position: clampedPosition });
     this.currentPosition = clampedPosition;
@@ -1155,6 +1187,7 @@ class QueueService {
     this.currentDuration = nextTrack.duration;
     this.isPaused = false;
     this.crossfadeStartedForTrackId = null;
+    this.syncCurrentDurationFromPlayer();
 
     this.broadcastQueueChange();
     this.broadcastState();


### PR DESCRIPTION
Closes #31

## 更新內容
- 修正切到下一首時偶發無聲，避免預載與 Crossfade 轉場遺失目標音量。
- 修正音量平衡對 YouTube loudness metadata 的換算與套用時機，讓不同歌曲的體感音量更一致。
- 修正音量平衡不再把偏安靜的歌曲額外放大，避免像 ROSÉ - toxic till the end (OFFICIAL MUSIC VIDEO) 這類官方 MV 被錯誤推高音量。
- 修正 Discover 介面「本站排名」歌曲長度被 0 覆蓋後顯示 0:00 的問題，並在讀榜時自動回填缺失 metadata。
- 更新 0.7.8 changelog / fallback release notes，補上 quiet-track normalization fix 與 regression tests。

## 驗證
- npm run typecheck
- ~/.bun/bin/bun test src/__tests__/queue.service.test.ts
- ~/.bun/bin/bun test src/__tests__/release-notes.service.test.ts
- ~/.bun/bin/bun test src/__tests__/api.system.test.ts
- ~/.bun/bin/bun test src/__tests__
- Backend: http://127.0.0.1:3000
- Frontend: http://127.0.0.1:5174/
