### PR TITLE
release: 0.7.8 volume playback fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - 📋 **播放清單**：查看和管理排隊中的歌曲
 - 📝 **同步歌詞**：即時顯示歌詞（支援 LRC 格式）
 - 🔄 **即時同步**：透過 WebSocket 即時更新所有客戶端的狀態
+- 🔉 **音量平衡**：依 YouTube loudness metadata 自動衰減偏 loud 的歌曲，不會額外放大較安靜的曲目
 - 💾 **持久化同步 Session**：容器重啟後保留配對關係，不需要重新配對
 - 🏷️ **版本可見性**：前端 Header 與後端 API 會顯示目前系統版本與 Git SHA
 
@@ -35,13 +36,13 @@
 
 ### 關鍵服務責任
 
-- [music.service.ts](/Users/bs10081/Developer/youtube_music_bot/src/services/music.service.ts)
+- [music.service.ts](src/services/music.service.ts)
   負責搜尋、歌詞、mix、串流 URL 提取
-- [queue.service.ts](/Users/bs10081/Developer/youtube_music_bot/src/services/queue.service.ts)
+- [queue.service.ts](src/services/queue.service.ts)
   負責 queue、mix、radio、播放策略與 fallback 決策
-- [player.service.ts](/Users/bs10081/Developer/youtube_music_bot/src/services/player.service.ts)
+- [player.service.ts](src/services/player.service.ts)
   負責 mpv 行程、IPC 狀態同步、pause/resume/seek/stop
-- [ytdlp.ts](/Users/bs10081/Developer/youtube_music_bot/src/utils/ytdlp.ts)
+- [ytdlp.ts](src/utils/ytdlp.ts)
   負責 `yt-dlp` extractor args 與 cookies 設定
 
 ### 與 anti-bot 有關的設定
@@ -146,7 +147,7 @@ bun run dev
 npm run dev:frontend
 ```
 
-前端會在 http://localhost:5173 啟動，並自動代理 API 到後端 http://localhost:3000。
+前端會在 http://localhost:5174 啟動，並自動代理 API 到後端 http://localhost:3000。
 
 **方式二：僅啟動後端（使用舊版 HTML5 前端）**
 
@@ -576,7 +577,7 @@ docker compose exec -T youtube-music-bot which yt-dlp
 docker compose exec -T youtube-music-bot yt-dlp --version
 ```
 
-本專案的 [Dockerfile](/Users/bs10081/Developer/youtube_music_bot/Dockerfile) 已經在 runtime image 中安裝 `yt-dlp`。
+本專案的 [Dockerfile](Dockerfile) 已經在 runtime image 中安裝 `yt-dlp`。
 
 ### 6. JSON Parse error: `Expected '}'`
 
@@ -639,7 +640,7 @@ volumes:
 
 Workflow 檔案位置：
 
-- [.github/workflows/docker-image.yml](/Users/bs10081/Developer/youtube_music_bot/.github/workflows/docker-image.yml)
+- [.github/workflows/docker-image.yml](.github/workflows/docker-image.yml)
 
 ### 需要設定的 GitHub Secrets
 
@@ -787,7 +788,7 @@ Workflow 檔案位置：
 ## 檔案結構
 
 ```
-youtube_music_bot/
+youtube-music-bot/
 ├── package.json
 ├── tsconfig.json
 ├── README.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-music-bot",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "YouTube Music 點歌機器人 WebUI",
   "type": "module",
   "scripts": {

--- a/src/__tests__/queue.service.test.ts
+++ b/src/__tests__/queue.service.test.ts
@@ -318,7 +318,7 @@ describe("QueueService - seekTo functionality", () => {
       expect(syncPreloadSpy).toHaveBeenCalledWith({ force: true });
     });
 
-    test("should prefer perceptual loudness metadata when resolving volume normalization", async () => {
+    test("should prefer perceptual loudness metadata without boosting quieter tracks", async () => {
       const musicService = getMusicService() as unknown as {
         getTrackLoudness: (videoId: string) => Promise<{
           loudnessDb?: number;
@@ -333,8 +333,8 @@ describe("QueueService - seekTo functionality", () => {
         musicService,
         "getTrackLoudness",
         (async () => ({
-          loudnessDb: -3,
-          perceptualLoudnessDb: -18,
+          loudnessDb: -4.2800007,
+          perceptualLoudnessDb: -18.28,
         })) as typeof musicService.getTrackLoudness,
       );
 
@@ -343,10 +343,10 @@ describe("QueueService - seekTo functionality", () => {
           track("track-perceptual", "Perceptual Track"),
         );
 
-      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, 4 / 20), 5);
+      expect(volumeMultiplier).toBe(1);
     });
 
-    test("should use a conservative loudnessDb fallback without boosting", async () => {
+    test("should still attenuate loud tracks when perceptual metadata exceeds the reference", async () => {
       const musicService = getMusicService() as unknown as {
         getTrackLoudness: (videoId: string) => Promise<{
           loudnessDb?: number;
@@ -361,20 +361,76 @@ describe("QueueService - seekTo functionality", () => {
         musicService,
         "getTrackLoudness",
         (async () => ({
-          loudnessDb: -8,
+          loudnessDb: 6.61,
+          perceptualLoudnessDb: -7.39,
         })) as typeof musicService.getTrackLoudness,
       );
 
       const volumeMultiplier =
         await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-fallback", "Fallback Track"),
+          track("track-perceptual-loud", "Perceptual Loud Track"),
         );
 
-      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, -8 / 20), 5);
+      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, -6.61 / 20), 5);
       expect(volumeMultiplier).toBeLessThan(1);
     });
 
-    test("should clamp normalization boost and attenuation boundaries", async () => {
+    test("should use a conservative loudnessDb fallback without boosting quieter tracks", async () => {
+      const musicService = getMusicService() as unknown as {
+        getTrackLoudness: (videoId: string) => Promise<{
+          loudnessDb?: number;
+          perceptualLoudnessDb?: number;
+        } | null>;
+      };
+      const internalQueueService = queueService as unknown as {
+        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
+      };
+
+      stubMethod(
+        musicService,
+        "getTrackLoudness",
+        (async () => ({
+          loudnessDb: -4.2800007,
+        })) as typeof musicService.getTrackLoudness,
+      );
+
+      const volumeMultiplier =
+        await internalQueueService.resolveTrackVolumeMultiplier(
+          track("track-fallback-quiet", "Fallback Quiet Track"),
+        );
+
+      expect(volumeMultiplier).toBe(1);
+    });
+
+    test("should attenuate loud tracks when only loudnessDb fallback is available", async () => {
+      const musicService = getMusicService() as unknown as {
+        getTrackLoudness: (videoId: string) => Promise<{
+          loudnessDb?: number;
+          perceptualLoudnessDb?: number;
+        } | null>;
+      };
+      const internalQueueService = queueService as unknown as {
+        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
+      };
+
+      stubMethod(
+        musicService,
+        "getTrackLoudness",
+        (async () => ({
+          loudnessDb: 6.21,
+        })) as typeof musicService.getTrackLoudness,
+      );
+
+      const volumeMultiplier =
+        await internalQueueService.resolveTrackVolumeMultiplier(
+          track("track-fallback-loud", "Fallback Loud Track"),
+        );
+
+      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, -6.21 / 20), 5);
+      expect(volumeMultiplier).toBeLessThan(1);
+    });
+
+    test("should clamp normalization gain to attenuation-only boundaries", async () => {
       const loudnessSamples = [
         { perceptualLoudnessDb: -30 },
         { perceptualLoudnessDb: 10 },
@@ -396,16 +452,16 @@ describe("QueueService - seekTo functionality", () => {
         (async () => loudnessSamples[callIndex++] ?? null) as typeof musicService.getTrackLoudness,
       );
 
-      const boostedMultiplier =
+      const quietTrackMultiplier =
         await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-boost", "Boosted Track"),
+          track("track-quiet", "Quiet Track"),
         );
       const attenuatedMultiplier =
         await internalQueueService.resolveTrackVolumeMultiplier(
           track("track-attenuate", "Attenuated Track"),
         );
 
-      expect(boostedMultiplier).toBeCloseTo(Math.pow(10, 6 / 20), 5);
+      expect(quietTrackMultiplier).toBe(1);
       expect(attenuatedMultiplier).toBeCloseTo(Math.pow(10, -12 / 20), 5);
     });
   });

--- a/src/__tests__/release-notes.service.test.ts
+++ b/src/__tests__/release-notes.service.test.ts
@@ -91,7 +91,7 @@ describe("ReleaseNotesService", () => {
     expect(response.source).toBe("fallback");
     expect(response.currentRelease?.version).toBe("0.7.0");
     expect(response.releases.map((entry) => entry.version)).toContain("0.7.0");
-    expect(response.releases[0]?.version).toBe("0.7.7");
+    expect(response.releases[0]?.version).toBe("0.7.8");
     expect(
       response.warnings.some((warning) => warning.includes("已改用本機版本說明")),
     ).toBe(true);

--- a/src/data/release-notes.ts
+++ b/src/data/release-notes.ts
@@ -1,6 +1,33 @@
 import type { ReleaseNotesEntry } from "../types/index.ts";
 
 const fallbackReleaseNotesByVersion: Record<string, ReleaseNotesEntry> = {
+  "0.7.8": {
+    version: "0.7.8",
+    title: "音量平衡過度放大修正",
+    publishedAt: "2026-03-30",
+    status: "preview",
+    summary:
+      "修正音量平衡會把偏安靜歌曲額外放大的問題，讓官方 MV 與一般音軌之間的聽感音量更穩定一致。",
+    sections: [
+      {
+        category: "fixed",
+        title: "音量平衡修復",
+        description: "避免 normalization 在遇到較安靜的歌曲時反而把它額外放大。",
+        items: [
+          "修正音量平衡只會衰減偏 loud 的曲目，不再因 YouTube loudness metadata 把較安靜的官方 MV 額外放大。",
+          "保留過大曲目的 attenuation cap，讓音量平衡開啟時仍能壓低像 How Sweet 這類本來偏 loud 的歌曲。",
+        ],
+      },
+      {
+        category: "fixed",
+        title: "回歸驗證補強",
+        description: "把這次真實 metadata case 轉成測試，避免 quiet track boost regression 再次出現。",
+        items: [
+          "補上 ROSÉ 官方 MV 與 loudness fallback 的 regression tests，確認安靜曲目維持 1x、偏 loud 曲目仍會被衰減。",
+        ],
+      },
+    ],
+  },
   "0.7.7": {
     version: "0.7.7",
     title: "音量播放與 Discover 修正",

--- a/src/services/queue.service.ts
+++ b/src/services/queue.service.ts
@@ -39,7 +39,7 @@ const MIN_CROSSFADE_START_POSITION_SECONDS = 5;
 const CROSSFADE_START_TOLERANCE_SECONDS = 0.35;
 const MAX_CROSSFADE_TRIGGER_LEAD_SECONDS = 1;
 const VOLUME_NORMALIZATION_REFERENCE_DB = -14;
-const MAX_VOLUME_NORMALIZATION_BOOST_DB = 6;
+const MAX_VOLUME_NORMALIZATION_GAIN_DB = 0;
 const MAX_VOLUME_NORMALIZATION_ATTENUATION_DB = 12;
 
 class QueueService {
@@ -1526,16 +1526,17 @@ function resolveNormalizationGainDb(
 
   const loudnessDb = loudnessInfo?.loudnessDb;
   if (typeof loudnessDb === "number" && Number.isFinite(loudnessDb)) {
-    return clampNormalizationGainDb(-Math.abs(loudnessDb));
+    return clampNormalizationGainDb(-loudnessDb);
   }
 
   return 0;
 }
 
+// Volume normalization only attenuates louder tracks and never boosts quieter ones.
 function clampNormalizationGainDb(gainDb: number): number {
   return Math.max(
     -MAX_VOLUME_NORMALIZATION_ATTENUATION_DB,
-    Math.min(MAX_VOLUME_NORMALIZATION_BOOST_DB, gainDb),
+    Math.min(MAX_VOLUME_NORMALIZATION_GAIN_DB, gainDb),
   );
 }
 


### PR DESCRIPTION
Closes #31

## 更新內容
- 修正切到下一首時偶發無聲，避免預載與 Crossfade 轉場遺失目標音量。
- 修正音量平衡對 YouTube loudness metadata 的換算與套用時機，讓不同歌曲的體感音量更一致。
- 修正音量平衡不再把偏安靜的歌曲額外放大，避免像 ROSÉ - toxic till the end (OFFICIAL MUSIC VIDEO) 這類官方 MV 被錯誤推高音量。
- 修正 Discover 介面「本站排名」歌曲長度被 0 覆蓋後顯示 0:00 的問題，並在讀榜時自動回填缺失 metadata。
- 更新 README 與 0.7.8 changelog / fallback release notes，補上 quiet-track normalization fix、實際前端 port 與文件連結修正。

## 驗證
- npm run typecheck
- ~/.bun/bin/bun test src/__tests__/queue.service.test.ts
- ~/.bun/bin/bun test src/__tests__/release-notes.service.test.ts
- ~/.bun/bin/bun test src/__tests__/api.system.test.ts
- ~/.bun/bin/bun test src/__tests__
- Backend: http://127.0.0.1:3000
- Frontend: http://127.0.0.1:5174/
