### PR TITLE
Strengthen yt-dlp fallback for YouTube playback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # Stage 1: 構建前端
 ARG APP_VERSION=0.2.0
 ARG APP_GIT_SHA=dev
+ARG YTDLP_VERSION=2026.03.17
 
 FROM node:20-slim AS frontend-builder
 ARG APP_VERSION
@@ -37,14 +38,26 @@ RUN bun build src/index.ts --outdir dist --target bun
 FROM oven/bun:1-slim
 ARG APP_VERSION
 ARG APP_GIT_SHA
+ARG YTDLP_VERSION
 WORKDIR /app
 
-# 安裝 mpv 和 yt-dlp
+# 安裝 mpv，並使用可控版本的 yt-dlp binary
 RUN apt-get update && apt-get install -y --no-install-recommends \
     mpv \
-    yt-dlp \
     ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      x86_64|amd64) ytdlp_asset="yt-dlp_linux" ;; \
+      aarch64|arm64) ytdlp_asset="yt-dlp_linux_aarch64" ;; \
+      armv7l|armhf) ytdlp_asset="yt-dlp_linux_armv7l" ;; \
+      *) echo "Unsupported architecture for yt-dlp binary: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -L "https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSION}/${ytdlp_asset}" -o /usr/local/bin/yt-dlp; \
+    chmod +x /usr/local/bin/yt-dlp; \
+    yt-dlp --version
 
 # 複製構建產物
 COPY --from=backend-builder /app/dist ./dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,12 @@ services:
       - LOG_LEVEL=INFO
       - SYNC_STATE_DB_PATH=/data/sync-state.sqlite
       - YTDLP_EXTRACTOR_ARGS=youtube:player_client=android_vr
+      # 如果生產 IP 被 YouTube 要求人類驗證，掛載 cookies 檔後取消註解：
+      # - YTDLP_COOKIES_FILE=/run/secrets/youtube-cookies.txt
     volumes:
       - sync-state:/data
+      # cookies 檔不會放進 image；需要時用唯讀 volume 掛載：
+      # - ./secrets/youtube-cookies.txt:/run/secrets/youtube-cookies.txt:ro
     labels:
       - com.centurylinklabs.watchtower.enable=true
     # 可選：如果需要 PulseAudio（取消註解以下配置）

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -25,6 +25,23 @@ export interface SystemInfoResponse {
   gitSha: string;
   buildVersion: string;
   environment: string;
+  runtimeDependencies?: {
+    mpv: {
+      available: boolean;
+      executable: string;
+      version?: string;
+      error?: string;
+    };
+    ytDlp: {
+      available: boolean;
+      executable: string;
+      version?: string;
+      extractorArgs: string;
+      cookiesConfigured: boolean;
+      cookiesReadable: boolean;
+      error?: string;
+    };
+  };
 }
 
 const API_BASE = "/api";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-music-bot",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "YouTube Music 點歌機器人 WebUI",
   "type": "module",
   "scripts": {

--- a/src/__tests__/api.system.test.ts
+++ b/src/__tests__/api.system.test.ts
@@ -56,6 +56,23 @@ describe("/api/system/info", () => {
         gitSha: string;
         buildVersion: string;
         environment: string;
+        runtimeDependencies: {
+          mpv: {
+            available: boolean;
+            executable: string;
+            version?: string;
+            error?: string;
+          };
+          ytDlp: {
+            available: boolean;
+            executable: string;
+            version?: string;
+            extractorArgs: string;
+            cookiesConfigured: boolean;
+            cookiesReadable: boolean;
+            error?: string;
+          };
+        };
       };
     };
 
@@ -64,6 +81,15 @@ describe("/api/system/info", () => {
     expect(payload.data.gitSha).toBeTruthy();
     expect(payload.data.buildVersion).toContain(payload.data.appVersion);
     expect(payload.data.environment).toBeTruthy();
+    expect(payload.data.runtimeDependencies.mpv.executable).toBeTruthy();
+    expect(payload.data.runtimeDependencies.ytDlp.executable).toBeTruthy();
+    expect(payload.data.runtimeDependencies.ytDlp.extractorArgs).toBeTruthy();
+    expect(typeof payload.data.runtimeDependencies.ytDlp.cookiesConfigured).toBe(
+      "boolean",
+    );
+    expect(typeof payload.data.runtimeDependencies.ytDlp.cookiesReadable).toBe(
+      "boolean",
+    );
   });
 
   test("should expose release notes through the system api", async () => {

--- a/src/__tests__/music.service.test.ts
+++ b/src/__tests__/music.service.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeMixTracks,
   normalizeMusicSearchItem,
   resolveCollectionArtist,
+  YtDlpCommandError,
 } from "../services/music.service.ts";
 import type { SearchResult, StreamUrlResult } from "../types/index.ts";
 
@@ -418,5 +419,93 @@ describe("MusicService mix normalization", () => {
 
     expect(extractionCalls).toBe(1);
     expect(first).toEqual(second);
+  });
+
+  test("should fall back to yt-dlp when youtubei.js stream extraction fails", async () => {
+    const musicService = getMusicService() as unknown as {
+      getStreamUrl: (videoId: string) => Promise<StreamUrlResult>;
+      runYtDlpCommand: (
+        args: string[],
+      ) => Promise<{ stdout: string; stderr: string }>;
+    };
+
+    stubMethod(Innertube, "create", (async () => ({
+      session: { player: {} },
+      getStreamingData: async () => {
+        throw new Error("No valid URL to decipher");
+      },
+      getInfo: async () => ({
+        chooseFormat: () => ({
+          itag: 140,
+          bitrate: 128000,
+          mime_type: "audio/mp4",
+          signature_cipher: "cipher",
+        }),
+      }),
+    })) as unknown as typeof Innertube.create);
+    stubMethod(
+      musicService,
+      "runYtDlpCommand",
+      (async () => ({
+        stdout:
+          "https://example.com/video\nhttps://rr.example.com/audio.webm\n",
+        stderr: "",
+      })) as typeof musicService.runYtDlpCommand,
+    );
+
+    const result = await musicService.getStreamUrl("fallback-track");
+
+    expect(result).toEqual({
+      url: "https://rr.example.com/audio.webm",
+      source: "yt-dlp",
+    });
+  });
+
+  test("should surface yt-dlp command failures with diagnostic details", async () => {
+    const musicService = getMusicService() as unknown as {
+      getStreamUrl: (videoId: string) => Promise<StreamUrlResult>;
+      runYtDlpCommand: (
+        args: string[],
+      ) => Promise<{ stdout: string; stderr: string }>;
+    };
+    const commandError = new YtDlpCommandError(
+      "yt-dlp exited with code 1",
+      {
+        executable: "/usr/local/bin/yt-dlp",
+        args: ["-g"],
+        exitCode: 1,
+        signal: null,
+        stdout: "",
+        stderr: "ERROR: Sign in to confirm you're not a bot",
+        timedOut: false,
+      },
+    );
+
+    stubMethod(Innertube, "create", (async () => ({
+      session: { player: {} },
+      getStreamingData: async () => {
+        throw new Error("No valid URL to decipher");
+      },
+      getInfo: async () => ({
+        chooseFormat: () => null,
+      }),
+    })) as unknown as typeof Innertube.create);
+    stubMethod(
+      musicService,
+      "runYtDlpCommand",
+      (async () => {
+        throw commandError;
+      }) as typeof musicService.runYtDlpCommand,
+    );
+
+    await expect(musicService.getStreamUrl("blocked-track")).rejects.toThrow(
+      "yt-dlp exited with code 1",
+    );
+    expect(commandError.details).toMatchObject({
+      executable: "/usr/local/bin/yt-dlp",
+      exitCode: 1,
+      timedOut: false,
+      stderr: "ERROR: Sign in to confirm you're not a bot",
+    });
   });
 });

--- a/src/__tests__/release-notes.service.test.ts
+++ b/src/__tests__/release-notes.service.test.ts
@@ -91,7 +91,7 @@ describe("ReleaseNotesService", () => {
     expect(response.source).toBe("fallback");
     expect(response.currentRelease?.version).toBe("0.7.0");
     expect(response.releases.map((entry) => entry.version)).toContain("0.7.0");
-    expect(response.releases[0]?.version).toBe("0.7.8");
+    expect(response.releases[0]?.version).toBe("0.7.9");
     expect(
       response.warnings.some((warning) => warning.includes("已改用本機版本說明")),
     ).toBe(true);

--- a/src/__tests__/ytdlp.test.ts
+++ b/src/__tests__/ytdlp.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getMpvYtdlRawOptions,
+  getYtDlpCliArgs,
+  getYtDlpCookiesStatus,
+  getYtDlpExecutable,
+  getYtDlpExtractorArgs,
+  parseYtDlpStreamUrlOutput,
+} from "../utils/ytdlp.ts";
+
+const ORIGINAL_ENV = { ...process.env };
+const tempDirs: string[] = [];
+
+function resetEnv(): void {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+function createTempDir(): string {
+  const path = mkdtempSync(join(tmpdir(), "youtube-music-bot-ytdlp-"));
+  tempDirs.push(path);
+  return path;
+}
+
+afterEach(() => {
+  resetEnv();
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { force: true, recursive: true });
+  }
+});
+
+describe("yt-dlp utilities", () => {
+  test("should resolve executable from env with YTDLP_PATH precedence", () => {
+    process.env.YTDLP_PATH = "/opt/bin/yt-dlp-custom";
+    process.env.YT_DLP_PATH = "/opt/bin/yt-dlp-legacy";
+
+    expect(getYtDlpExecutable()).toBe("/opt/bin/yt-dlp-custom");
+
+    process.env.YTDLP_PATH = "";
+
+    expect(getYtDlpExecutable()).toBe("/opt/bin/yt-dlp-legacy");
+  });
+
+  test("should use default extractor args unless overridden", () => {
+    delete process.env.YTDLP_EXTRACTOR_ARGS;
+
+    expect(getYtDlpExtractorArgs()).toBe("youtube:player_client=android_vr");
+
+    process.env.YTDLP_EXTRACTOR_ARGS = "youtube:player_client=web";
+
+    expect(getYtDlpExtractorArgs()).toBe("youtube:player_client=web");
+  });
+
+  test("should report cookies file readability", () => {
+    const dir = createTempDir();
+    const cookiesPath = join(dir, "cookies.txt");
+    process.env.YTDLP_COOKIES_FILE = cookiesPath;
+
+    expect(getYtDlpCookiesStatus()).toMatchObject({
+      configured: true,
+      path: cookiesPath,
+      readable: false,
+    });
+
+    writeFileSync(cookiesPath, "# Netscape HTTP Cookie File\n");
+
+    expect(getYtDlpCookiesStatus()).toEqual({
+      configured: true,
+      path: cookiesPath,
+      readable: true,
+    });
+  });
+
+  test("should include extractor args and readable cookies in CLI args", () => {
+    const dir = createTempDir();
+    const cookiesPath = join(dir, "cookies.txt");
+    writeFileSync(cookiesPath, "# Netscape HTTP Cookie File\n");
+    process.env.YTDLP_COOKIES_FILE = cookiesPath;
+    process.env.YTDLP_EXTRACTOR_ARGS = "youtube:player_client=web";
+
+    expect(getYtDlpCliArgs("https://example.com/watch?v=1")).toEqual([
+      "--no-warnings",
+      "--no-playlist",
+      "-g",
+      "-f",
+      "bestaudio/best",
+      "--extractor-args",
+      "youtube:player_client=web",
+      "--cookies",
+      cookiesPath,
+      "https://example.com/watch?v=1",
+    ]);
+    expect(getMpvYtdlRawOptions()).toEqual([
+      "extractor-args=[youtube:player_client=web]",
+      `cookies=${cookiesPath}`,
+    ]);
+  });
+
+  test("should parse the last non-empty playable URL from yt-dlp output", () => {
+    expect(
+      parseYtDlpStreamUrlOutput(
+        "\nhttps://example.com/video\nhttps://example.com/audio\n",
+      ),
+    ).toBe("https://example.com/audio");
+  });
+
+  test("should reject empty, invalid, or unsupported stream URLs", () => {
+    expect(() => parseYtDlpStreamUrlOutput("")).toThrow(
+      "yt-dlp did not return a playable URL",
+    );
+    expect(() => parseYtDlpStreamUrlOutput("not-a-url")).toThrow(
+      "yt-dlp returned an invalid playable URL",
+    );
+    expect(() => parseYtDlpStreamUrlOutput("file:///tmp/audio.webm")).toThrow(
+      "unsupported playable URL protocol",
+    );
+  });
+});

--- a/src/data/release-notes.ts
+++ b/src/data/release-notes.ts
@@ -1,6 +1,34 @@
 import type { ReleaseNotesEntry } from "../types/index.ts";
 
 const fallbackReleaseNotesByVersion: Record<string, ReleaseNotesEntry> = {
+  "0.7.9": {
+    version: "0.7.9",
+    title: "yt-dlp 播放備援強化",
+    publishedAt: "2026-05-08",
+    status: "preview",
+    summary:
+      "強化 yt-dlp 作為生產播放備援路徑，讓 YouTube 串流解析失敗時更快切換、更容易診斷部署環境。",
+    sections: [
+      {
+        category: "changed",
+        title: "播放備援強化",
+        description: "把 yt-dlp 從最後保底提升為可觀測、可診斷的穩定播放路徑。",
+        items: [
+          "youtubei.js 直接串流失敗時會清楚記錄錯誤類型，並快速切到 yt-dlp 取得可播放 URL。",
+          "yt-dlp fallback 新增 timeout、stderr、exit code 與 URL scheme 驗證，讓生產錯誤更容易定位。",
+        ],
+      },
+      {
+        category: "added",
+        title: "部署診斷資訊",
+        description: "讓部署者能直接確認播放依賴是否真的可用。",
+        items: [
+          "系統資訊 API 新增 mpv 與 yt-dlp runtime 狀態，包含版本、執行檔、extractor args 與 cookies 可讀狀態。",
+          "Docker 部署改用可確認版本的 yt-dlp binary，並保留 cookies 檔掛載範例。",
+        ],
+      },
+    ],
+  },
   "0.7.8": {
     version: "0.7.8",
     title: "音量平衡過度放大修正",

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -15,6 +15,7 @@ import {
   isAllowedArtworkUrl,
   parseArtworkUrl,
 } from "../utils/artwork-proxy.ts";
+import { getRuntimeDependencyStatus } from "../utils/runtime-dependencies.ts";
 
 const api = new Hono();
 
@@ -866,7 +867,10 @@ api.delete("/queue/:index", (c) => {
 api.get("/system/info", (c) =>
   c.json<ApiResponse>({
     success: true,
-    data: getAppMetadata(),
+    data: {
+      ...getAppMetadata(),
+      runtimeDependencies: getRuntimeDependencyStatus(),
+    },
   }),
 );
 

--- a/src/services/music.service.ts
+++ b/src/services/music.service.ts
@@ -21,9 +21,12 @@ import { log } from "../utils/logger.ts";
 import { join } from "node:path";
 import { existsSync, mkdirSync } from "node:fs";
 import {
+  getYtDlpCommandTimeoutMs,
   getYtDlpCliArgs,
   getYtDlpExecutable,
+  getYtDlpFailureHint,
   getYtDlpMetadataArgs,
+  parseYtDlpStreamUrlOutput,
 } from "../utils/ytdlp.ts";
 import {
   parseYouTubeUrl,
@@ -1014,6 +1017,32 @@ function parseLrc(lrc: string): LyricLine[] {
 
 const STREAM_URL_CACHE_TTL_MS = 10 * 60 * 1000;
 
+export type YtDlpCommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+export type YtDlpCommandErrorDetails = {
+  executable: string;
+  args: string[];
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  cause?: unknown;
+};
+
+export class YtDlpCommandError extends Error {
+  readonly details: YtDlpCommandErrorDetails;
+
+  constructor(message: string, details: YtDlpCommandErrorDetails) {
+    super(message);
+    this.name = "YtDlpCommandError";
+    this.details = details;
+  }
+}
+
 class MusicService {
   private searchCache = new Map<string, SearchResult[]>();
   private lyricsCache = new Map<string, LyricLine[]>();
@@ -1730,19 +1759,32 @@ class MusicService {
         });
 
         const formatAny = format as any;
-      if (formatAny?.url && formatAny.url.length > 0) {
-        log.info("Stream URL obtained", {
-          bitrate: formatAny.bitrate,
-          urlLength: formatAny.url.length,
+        if (formatAny?.url && formatAny.url.length > 0) {
+          log.info("Stream URL obtained", {
+            bitrate: formatAny.bitrate,
+            urlLength: formatAny.url.length,
+            source: "youtubei",
+          });
+          return {
+            url: formatAny.url,
+            source: "youtubei",
+            bitrate: formatAny.bitrate,
+          };
+        }
+
+        log.warn("youtubei.js getStreamingData returned no direct URL", {
+          videoId,
+          hasFormat: Boolean(formatAny),
+          hasCipher: Boolean(formatAny?.cipher || formatAny?.signature_cipher),
+          itag: formatAny?.itag,
+          mimeType: formatAny?.mime_type ?? formatAny?.mimeType,
         });
-        return {
-          url: formatAny.url,
-          source: "youtubei",
-          bitrate: formatAny.bitrate,
-        };
-      }
       } catch (e) {
-        // getStreamingData 失敗，繼續嘗試其他方法
+        log.warn("youtubei.js getStreamingData failed", {
+          error: e instanceof Error ? e.message : String(e),
+          errorName: e instanceof Error ? e.name : typeof e,
+          videoId,
+        });
       }
 
       // Fallback: getInfo + chooseFormat
@@ -1757,6 +1799,7 @@ class MusicService {
         if (url && url.length > 0) {
           log.info("Stream URL obtained via chooseFormat", {
             bitrate: format.bitrate,
+            source: "youtubei",
           });
           return {
             url,
@@ -1766,10 +1809,20 @@ class MusicService {
         }
       }
 
+      log.warn("youtubei.js chooseFormat returned no direct URL", {
+        videoId,
+        hasFormat: Boolean(format),
+        hasCipher: Boolean(
+          (format as any)?.cipher || (format as any)?.signature_cipher,
+        ),
+        itag: format?.itag,
+        mimeType: (format as any)?.mime_type ?? (format as any)?.mimeType,
+      });
       throw new Error("No suitable audio stream found");
     } catch (error) {
       log.warn("Primary stream extraction failed, trying yt-dlp CLI fallback", {
         error: error instanceof Error ? error.message : String(error),
+        errorName: error instanceof Error ? error.name : typeof error,
         videoId,
       });
 
@@ -1783,20 +1836,12 @@ class MusicService {
 
   private async getStreamUrlViaYtDlp(url: string): Promise<string> {
     const { stdout } = await this.runYtDlpCommand(getYtDlpCliArgs(url));
-    const urls = stdout
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
-
-    const streamUrl = urls[urls.length - 1];
-
-    if (!streamUrl) {
-      throw new Error("yt-dlp did not return a playable URL");
-    }
+    const streamUrl = parseYtDlpStreamUrlOutput(stdout);
 
     log.info("Stream URL obtained via yt-dlp CLI", {
+      source: "yt-dlp",
       urlLength: streamUrl.length,
-      lineCount: urls.length,
+      lineCount: stdout.split("\n").filter((line) => line.trim()).length,
     });
 
     return streamUrl;
@@ -1825,13 +1870,46 @@ class MusicService {
 
   private async runYtDlpCommand(
     args: string[],
-  ): Promise<{ stdout: string; stderr: string }> {
-    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-      const child = spawn(getYtDlpExecutable(), args, {
+  ): Promise<YtDlpCommandResult> {
+    return new Promise<YtDlpCommandResult>((resolve, reject) => {
+      const executable = getYtDlpExecutable();
+      const timeoutMs = getYtDlpCommandTimeoutMs();
+      const child = spawn(executable, args, {
         stdio: ["ignore", "pipe", "pipe"],
       });
       let stdout = "";
       let stderr = "";
+      let settled = false;
+      let timedOut = false;
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, timeoutMs);
+
+      const finishWithError = (error: YtDlpCommandError) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+
+        const hint = getYtDlpFailureHint(error.message);
+        if (hint) {
+          error.message = `${error.message} ${hint}`;
+        }
+
+        log.warn("yt-dlp command failed", {
+          executable,
+          args,
+          exitCode: error.details.exitCode,
+          signal: error.details.signal,
+          timedOut: error.details.timedOut,
+          stderr: error.details.stderr,
+          stdout: error.details.stdout,
+          error: error.message,
+        });
+        reject(error);
+      };
 
       child.stdout?.on("data", (data: Buffer) => {
         stdout += data.toString();
@@ -1842,19 +1920,47 @@ class MusicService {
       });
 
       child.on("error", (error) => {
-        reject(error);
+        finishWithError(
+          new YtDlpCommandError(`Failed to start yt-dlp: ${error.message}`, {
+            executable,
+            args,
+            stdout: stdout.trim(),
+            stderr: stderr.trim(),
+            timedOut,
+            cause: error,
+          }),
+        );
       });
 
-      child.on("exit", (code) => {
+      child.on("exit", (code, signal) => {
+        if (settled) {
+          return;
+        }
+        clearTimeout(timeout);
+
         if (code !== 0) {
-          reject(
-            new Error(
-              stderr.trim() || `yt-dlp exited with code ${code ?? "unknown"}`,
-            ),
+          const stderrText = stderr.trim();
+          const stdoutText = stdout.trim();
+          const message = timedOut
+            ? `yt-dlp timed out after ${timeoutMs}ms`
+            : stderrText ||
+              stdoutText ||
+              `yt-dlp exited with code ${code ?? "unknown"}`;
+          finishWithError(
+            new YtDlpCommandError(message, {
+              executable,
+              args,
+              exitCode: code,
+              signal,
+              stdout: stdoutText,
+              stderr: stderrText,
+              timedOut,
+            }),
           );
           return;
         }
 
+        settled = true;
         resolve({
           stdout: stdout.trim(),
           stderr: stderr.trim(),

--- a/src/utils/runtime-dependencies.ts
+++ b/src/utils/runtime-dependencies.ts
@@ -1,18 +1,30 @@
 import { spawnSync } from "node:child_process";
 import { log } from "./logger.ts";
-import { getYtDlpExecutable } from "./ytdlp.ts";
+import { probeYtDlpRuntime } from "./ytdlp.ts";
 
 type RuntimeDependency = {
-  name: "mpv" | "yt-dlp";
+  name: "mpv";
   executable: string;
   required: boolean;
   purpose: string;
 };
 
-type DependencyProbeResult = {
+export type DependencyProbeResult = {
   available: boolean;
+  executable: string;
   version?: string;
   error?: string;
+};
+
+export type YtDlpDependencyProbeResult = DependencyProbeResult & {
+  extractorArgs: string;
+  cookiesConfigured: boolean;
+  cookiesReadable: boolean;
+};
+
+export type RuntimeDependencyStatus = {
+  mpv: DependencyProbeResult;
+  ytDlp: YtDlpDependencyProbeResult;
 };
 
 export function getMpvExecutable(): string {
@@ -33,6 +45,7 @@ function probeExecutable(executable: string): DependencyProbeResult {
   if (result.error) {
     return {
       available: false,
+      executable,
       error: result.error.message,
     };
   }
@@ -40,6 +53,7 @@ function probeExecutable(executable: string): DependencyProbeResult {
   if (result.status !== 0) {
     return {
       available: false,
+      executable,
       error:
         result.stderr.trim() ||
         result.stdout.trim() ||
@@ -52,7 +66,26 @@ function probeExecutable(executable: string): DependencyProbeResult {
 
   return {
     available: true,
+    executable,
     version: versionLine,
+  };
+}
+
+export function getRuntimeDependencyStatus(): RuntimeDependencyStatus {
+  const mpv = probeExecutable(getMpvExecutable());
+  const ytDlp = probeYtDlpRuntime();
+
+  return {
+    mpv,
+    ytDlp: {
+      available: ytDlp.available,
+      executable: ytDlp.executable,
+      version: ytDlp.version,
+      extractorArgs: ytDlp.extractorArgs,
+      cookiesConfigured: ytDlp.cookiesConfigured,
+      cookiesReadable: ytDlp.cookiesReadable,
+      error: ytDlp.error,
+    },
   };
 }
 
@@ -63,12 +96,6 @@ export function logRuntimeDependencyStatus(): void {
       executable: getMpvExecutable(),
       required: true,
       purpose: "audio playback",
-    },
-    {
-      name: "yt-dlp",
-      executable: getYtDlpExecutable(),
-      required: false,
-      purpose: "YouTube fallback extraction",
     },
   ];
 
@@ -98,5 +125,36 @@ export function logRuntimeDependencyStatus(): void {
     }
 
     log.warn("Optional runtime dependency missing", context);
+  }
+
+  const ytDlp = probeYtDlpRuntime();
+  if (ytDlp.available) {
+    log.info("Runtime dependency available", {
+      dependency: "yt-dlp",
+      executable: ytDlp.executable,
+      version: ytDlp.version,
+      purpose: "YouTube fallback extraction",
+      extractorArgs: ytDlp.extractorArgs,
+      cookiesConfigured: ytDlp.cookiesConfigured,
+      cookiesReadable: ytDlp.cookiesReadable,
+    });
+  } else {
+    log.warn("Optional runtime dependency missing", {
+      dependency: "yt-dlp",
+      executable: ytDlp.executable,
+      purpose: "YouTube fallback extraction",
+      error: ytDlp.error,
+      extractorArgs: ytDlp.extractorArgs,
+      cookiesConfigured: ytDlp.cookiesConfigured,
+      cookiesReadable: ytDlp.cookiesReadable,
+    });
+  }
+
+  if (ytDlp.cookiesConfigured && !ytDlp.cookiesReadable) {
+    log.warn("Configured yt-dlp cookies file is not readable", {
+      dependency: "yt-dlp",
+      cookiesPath: ytDlp.cookiesPath,
+      error: ytDlp.error,
+    });
   }
 }

--- a/src/utils/ytdlp.ts
+++ b/src/utils/ytdlp.ts
@@ -1,6 +1,26 @@
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 const DEFAULT_EXTRACTOR_ARGS = "youtube:player_client=android_vr";
+const DEFAULT_COMMAND_TIMEOUT_MS = 45_000;
+
+export type YtDlpCookiesStatus = {
+  configured: boolean;
+  path: string | null;
+  readable: boolean;
+  error?: string;
+};
+
+export type YtDlpRuntimeProbe = {
+  available: boolean;
+  executable: string;
+  version?: string;
+  extractorArgs: string;
+  cookiesConfigured: boolean;
+  cookiesReadable: boolean;
+  cookiesPath: string | null;
+  error?: string;
+};
 
 function normalizeEnvValue(value: string | undefined): string | null {
   const trimmed = value?.trim();
@@ -22,14 +42,60 @@ export function getYtDlpExtractorArgs(): string {
   );
 }
 
-export function getYtDlpCookiesPath(): string | null {
+export function getYtDlpCommandTimeoutMs(): number {
+  const configuredTimeout = Number.parseInt(
+    normalizeEnvValue(process.env.YTDLP_TIMEOUT_MS) ?? "",
+    10,
+  );
+
+  if (Number.isFinite(configuredTimeout) && configuredTimeout > 0) {
+    return configuredTimeout;
+  }
+
+  return DEFAULT_COMMAND_TIMEOUT_MS;
+}
+
+export function getYtDlpCookiesStatus(): YtDlpCookiesStatus {
   const cookiePath = normalizeEnvValue(process.env.YTDLP_COOKIES_FILE);
 
   if (!cookiePath) {
-    return null;
+    return {
+      configured: false,
+      path: null,
+      readable: false,
+    };
   }
 
-  return existsSync(cookiePath) ? cookiePath : null;
+  if (!existsSync(cookiePath)) {
+    return {
+      configured: true,
+      path: cookiePath,
+      readable: false,
+      error: "configured cookies file does not exist",
+    };
+  }
+
+  try {
+    accessSync(cookiePath, constants.R_OK);
+  } catch (error) {
+    return {
+      configured: true,
+      path: cookiePath,
+      readable: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  return {
+    configured: true,
+    path: cookiePath,
+    readable: true,
+  };
+}
+
+export function getYtDlpCookiesPath(): string | null {
+  const cookies = getYtDlpCookiesStatus();
+  return cookies.readable ? cookies.path : null;
 }
 
 export function getYtDlpCliArgs(url: string): string[] {
@@ -53,6 +119,94 @@ export function getYtDlpCliArgs(url: string): string[] {
 
   args.push(url);
   return args;
+}
+
+export function parseYtDlpStreamUrlOutput(stdout: string): string {
+  const urls = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const streamUrl = urls[urls.length - 1];
+
+  if (!streamUrl) {
+    throw new Error("yt-dlp did not return a playable URL");
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(streamUrl);
+  } catch {
+    throw new Error("yt-dlp returned an invalid playable URL");
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error(
+      `yt-dlp returned an unsupported playable URL protocol: ${parsedUrl.protocol}`,
+    );
+  }
+
+  return streamUrl;
+}
+
+export function getYtDlpFailureHint(message: string): string | null {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("sign in to confirm") ||
+    normalized.includes("confirm you're not a bot") ||
+    normalized.includes("not a bot") ||
+    normalized.includes("cookies")
+  ) {
+    return "YouTube may require cookies for this IP; configure YTDLP_COOKIES_FILE with a readable cookies.txt file.";
+  }
+
+  return null;
+}
+
+export function probeYtDlpRuntime(): YtDlpRuntimeProbe {
+  const executable = getYtDlpExecutable();
+  const cookies = getYtDlpCookiesStatus();
+  const probe = spawnSync(executable, ["--version"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const base = {
+    executable,
+    extractorArgs: getYtDlpExtractorArgs(),
+    cookiesConfigured: cookies.configured,
+    cookiesReadable: cookies.readable,
+    cookiesPath: cookies.path,
+  };
+
+  if (probe.error) {
+    return {
+      ...base,
+      available: false,
+      error: probe.error.message,
+    };
+  }
+
+  if (probe.status !== 0) {
+    return {
+      ...base,
+      available: false,
+      error:
+        probe.stderr.trim() ||
+        probe.stdout.trim() ||
+        `exited with code ${probe.status ?? "unknown"}`,
+    };
+  }
+
+  const version =
+    `${probe.stdout}`.trim().split(/\r?\n/).find(Boolean) ?? "unknown";
+
+  return {
+    ...base,
+    available: true,
+    version,
+    error: cookies.error,
+  };
 }
 
 export function getYtDlpMetadataArgs(


### PR DESCRIPTION
## Summary
- strengthen yt-dlp as the production playback fallback with timeout, stderr/exit code diagnostics, URL validation, and bot/cookies hints
- expose mpv and yt-dlp runtime dependency status through `/api/system/info`
- pin Docker yt-dlp binary installation and document cookies volume setup
- bump root package version to 0.7.9 and add local release notes

## Tests
- `bun test src/__tests__`
- `bun run typecheck`
- Browser manual playback check at `http://127.0.0.1:5174/` using a YouTube URL, confirmed fallback to `source: "yt-dlp"` and mpv playback
