### PR TITLE
feat: v0.8.0 — dynaudnorm 音量平衡、Discovery 個人化、安全修補、CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# ===== 伺服器 =====
+# HTTP 服務埠號(預設 3000)
+#PORT=3000
+# 綁定的主機位址;未設定時由 Bun 預設(0.0.0.0)
+#HOST=0.0.0.0
+# production 時改用 frontend/dist 提供前端靜態檔
+#NODE_ENV=production
+# 日誌等級:DEBUG | INFO | WARN | ERROR(預設 INFO)
+#LOG_LEVEL=INFO
+
+# ===== 安全性 =====
+# CORS 允許來源白名單(逗號分隔)。設定後才會啟用 credentials;
+# 未設定時為開放 origin(適合僅限 LAN 的部署)。
+#CORS_ORIGIN=https://music.example.com,http://192.168.1.10:3000
+
+# ===== yt-dlp =====
+# yt-dlp 執行檔路徑(預設從 PATH 找 yt-dlp;也接受 YT_DLP_PATH)
+#YTDLP_PATH=/usr/local/bin/yt-dlp
+# 傳給 yt-dlp 的 extractor 參數(預設 youtube:player_client=android_vr)
+#YTDLP_EXTRACTOR_ARGS=youtube:player_client=android_vr
+# yt-dlp 執行逾時(毫秒,預設 45000)
+#YTDLP_TIMEOUT_MS=45000
+# YouTube cookies 檔路徑(遇到人類驗證時使用;用唯讀 volume 掛載,勿放進 image)
+#YTDLP_COOKIES_FILE=/run/secrets/youtube-cookies.txt
+
+# ===== 播放器 =====
+# mpv 執行檔路徑(預設從 PATH 找 mpv)
+#MPV_PATH=/usr/local/bin/mpv
+
+# ===== 資料庫 =====
+# 裝置配對同步狀態 SQLite 路徑(Docker 預設 /data/sync-state.sqlite)
+#SYNC_STATE_DB_PATH=/data/sync-state.sqlite
+# Discover 點播統計 SQLite 路徑(預設 .data/discover-stats.sqlite)
+#DISCOVER_STATS_DB_PATH=/data/discover-stats.sqlite
+
+# ===== 版本資訊(通常由 CI / Docker build 注入) =====
+#APP_VERSION=
+#APP_GIT_SHA=
+
+# ===== Release Notes(選用) =====
+# 提高 GitHub API rate limit 用的 token(只需 public repo 讀取權限)
+#GITHUB_TOKEN=
+#GITHUB_API_BASE_URL=https://api.github.com
+#RELEASE_NOTES_GITHUB_REPOSITORY=bs10081/youtube-music-bot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: true  # 需要 GitHub Dependency graph 功能開啟;未開啟時不阻塞 merge
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend (typecheck + tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Run tests
+        run: bun test src/__tests__
+
+  frontend:
+    name: Frontend (typecheck + build)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build (includes tsc -b)
+        run: npm run build
+
+  hadolint:
+    name: Dockerfile lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: error
+
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,6 @@ Thumbs.db
 .cache/
 .data/
 .codex/
+.claude/
 youtube-music-bot-arm64.tar
 youtube-music-cli-explore/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repository Rules
+
+- Root `package.json` is the version source of truth for this repository.
+- Every repository update must also update the root `package.json` version before commit, push, or PR creation.
+- Treat backend and frontend version metadata as derived from root `package.json`, and validate version-sensitive changes against that source of truth.
+
+## Communication
+
+- Use Traditional Chinese (Taiwan) when communicating with the user.
+
+## Local Validation
+
+- Before asking the user to manually inspect UI or integration changes, start the split development servers for this repo first: backend with `bun run dev` and frontend with `npm run dev:frontend` (or `cd frontend && npm run dev`).
+- Report the actual reachable local URLs/ports in handoff notes instead of assuming defaults.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # 多階段構建
 # Stage 1: 構建前端
-ARG APP_VERSION=0.7.10
+ARG APP_VERSION=0.8.0
 ARG APP_GIT_SHA=dev
 ARG YTDLP_VERSION=2026.03.17
 
@@ -56,6 +56,11 @@ RUN set -eux; \
       *) echo "Unsupported architecture for yt-dlp binary: $arch" >&2; exit 1 ;; \
     esac; \
     curl -L "https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSION}/${ytdlp_asset}" -o /usr/local/bin/yt-dlp; \
+    curl -L "https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSION}/SHA2-256SUMS" -o /tmp/yt-dlp-SHA2-256SUMS; \
+    expected_sha="$(awk -v asset="$ytdlp_asset" '$2 == asset || $2 == "*"asset {print $1}' /tmp/yt-dlp-SHA2-256SUMS)"; \
+    test -n "$expected_sha"; \
+    echo "${expected_sha}  /usr/local/bin/yt-dlp" | sha256sum -c -; \
+    rm /tmp/yt-dlp-SHA2-256SUMS; \
     chmod +x /usr/local/bin/yt-dlp; \
     yt-dlp --version
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
       - sync-state:/data
       # cookies 檔不會放進 image；需要時用唯讀 volume 掛載：
       # - ./secrets/youtube-cookies.txt:/run/secrets/youtube-cookies.txt:ro
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     labels:
       - com.centurylinklabs.watchtower.enable=true
     # 可選：如果需要 PulseAudio（取消註解以下配置）

--- a/frontend/src/components/discover/DiscoverView.tsx
+++ b/frontend/src/components/discover/DiscoverView.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -6,6 +7,7 @@ import {
   useState,
   type ReactNode,
   type RefObject,
+  type WheelEvent,
 } from "react";
 import {
   AlertTriangle,
@@ -21,6 +23,7 @@ import {
   PlayCircle,
   Radio,
   RefreshCw,
+  Sparkles,
 } from "lucide-react";
 import { OpenAlbumButton } from "@/components/album/OpenAlbumButton";
 import { OpenArtistButton } from "@/components/artist/OpenArtistButton";
@@ -78,6 +81,8 @@ interface DiscoverCardDestination {
   onOpen: (() => void) | null;
 }
 
+type DiscoverRailScrollState = "idle" | "active" | "settling";
+
 const MUSIC_VIDEO_SECTION_PATTERNS = [
   /latest\s+music\s+videos?/iu,
   /music\s+videos?/iu,
@@ -101,6 +106,8 @@ const DISCOVER_RAIL_FOCUS_MIN = 48;
 const DISCOVER_RAIL_FOCUS_MAX = 96;
 const DISCOVER_RAIL_FOCUS_RATIO = 0.12;
 const DISCOVER_RAIL_FEATURED_THRESHOLD = 0.58;
+const DISCOVER_RAIL_SETTLE_DELAY_MS = 700;
+const DISCOVER_RAIL_SETTLE_DURATION_MS = 320;
 
 const collectionPreviewCache = new Map<string, DiscoverCollectionPreview>();
 const collectionPreviewInFlight = new Map<
@@ -409,6 +416,59 @@ function InfoPill({
   );
 }
 
+function canScrollHorizontally(viewport: HTMLDivElement): boolean {
+  return viewport.scrollWidth - viewport.clientWidth > 2;
+}
+
+function freezeDiscoverRailLayout(viewport: HTMLDivElement) {
+  viewport.querySelectorAll<HTMLElement>(".discover-rail-item").forEach((node) => {
+    const currentEmphasis =
+      node.style.getPropertyValue("--discover-rail-emphasis") || "0";
+
+    node.style.setProperty("--discover-rail-frozen-emphasis", currentEmphasis);
+  });
+}
+
+function resolveNearestRailScrollLeft(viewport: HTMLDivElement): number | null {
+  const content = viewport.firstElementChild;
+  if (!content) {
+    return null;
+  }
+
+  const items = Array.from(content.children).filter(
+    (child): child is HTMLElement => child instanceof HTMLElement,
+  );
+  if (items.length === 0) {
+    return null;
+  }
+
+  const viewportRect = viewport.getBoundingClientRect();
+  const nearestItem = items.reduce<HTMLElement | null>((nearest, item) => {
+    if (!nearest) {
+      return item;
+    }
+
+    const nearestDistance = Math.abs(
+      nearest.getBoundingClientRect().left - viewportRect.left,
+    );
+    const itemDistance = Math.abs(item.getBoundingClientRect().left - viewportRect.left);
+
+    return itemDistance < nearestDistance ? item : nearest;
+  }, null);
+
+  if (!nearestItem) {
+    return null;
+  }
+
+  const targetLeft =
+    viewport.scrollLeft +
+    nearestItem.getBoundingClientRect().left -
+    viewportRect.left;
+  const maxScrollLeft = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
+
+  return Math.max(0, Math.min(targetLeft, maxScrollLeft));
+}
+
 function DiscoverHorizontalRail({
   children,
   className,
@@ -422,18 +482,160 @@ function DiscoverHorizontalRail({
   contentClassName?: string;
   viewportRef?: RefObject<HTMLDivElement | null>;
 }) {
+  const localViewportRef = useRef<HTMLDivElement | null>(null);
+  const [scrollState, setScrollState] = useState<DiscoverRailScrollState>("idle");
+  const scrollStateRef = useRef<DiscoverRailScrollState>("idle");
+  const settleTimerRef = useRef<number | null>(null);
+  const settleFinishTimerRef = useRef<number | null>(null);
+
+  const setNextScrollState = (nextState: DiscoverRailScrollState) => {
+    if (scrollStateRef.current === nextState) {
+      return;
+    }
+
+    scrollStateRef.current = nextState;
+    setScrollState(nextState);
+  };
+
+  const clearSettleTimers = () => {
+    if (settleTimerRef.current !== null) {
+      window.clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = null;
+    }
+
+    if (settleFinishTimerRef.current !== null) {
+      window.clearTimeout(settleFinishTimerRef.current);
+      settleFinishTimerRef.current = null;
+    }
+  };
+
+  const beginInteraction = () => {
+    const viewport = localViewportRef.current;
+    if (!viewport || !canScrollHorizontally(viewport)) {
+      return;
+    }
+
+    if (settleTimerRef.current !== null) {
+      window.clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = null;
+    }
+
+    if (settleFinishTimerRef.current !== null) {
+      window.clearTimeout(settleFinishTimerRef.current);
+      settleFinishTimerRef.current = null;
+    }
+
+    if (scrollStateRef.current !== "active") {
+      freezeDiscoverRailLayout(viewport);
+    }
+
+    setNextScrollState("active");
+  };
+
+  const settleToNearestItem = () => {
+    const viewport = localViewportRef.current;
+    if (!viewport || !canScrollHorizontally(viewport)) {
+      setNextScrollState("idle");
+      return;
+    }
+
+    freezeDiscoverRailLayout(viewport);
+    setNextScrollState("settling");
+
+    const nearestScrollLeft = resolveNearestRailScrollLeft(viewport);
+    if (
+      nearestScrollLeft !== null &&
+      Math.abs(viewport.scrollLeft - nearestScrollLeft) > 1
+    ) {
+      viewport.scrollTo({
+        left: nearestScrollLeft,
+        behavior: "smooth",
+      });
+    }
+
+    settleFinishTimerRef.current = window.setTimeout(() => {
+      settleFinishTimerRef.current = null;
+      setNextScrollState("idle");
+    }, DISCOVER_RAIL_SETTLE_DURATION_MS);
+  };
+
+  const scheduleDeferredSettle = () => {
+    const viewport = localViewportRef.current;
+    if (!viewport || !canScrollHorizontally(viewport)) {
+      return;
+    }
+
+    if (settleTimerRef.current !== null) {
+      window.clearTimeout(settleTimerRef.current);
+    }
+
+    settleTimerRef.current = window.setTimeout(() => {
+      settleTimerRef.current = null;
+      settleToNearestItem();
+    }, DISCOVER_RAIL_SETTLE_DELAY_MS);
+  };
+
+  const handleScroll = () => {
+    if (scrollStateRef.current === "settling") {
+      return;
+    }
+
+    beginInteraction();
+    scheduleDeferredSettle();
+  };
+
+  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+    if (Math.abs(event.deltaX) < Math.abs(event.deltaY) && !event.shiftKey) {
+      return;
+    }
+
+    beginInteraction();
+    scheduleDeferredSettle();
+  };
+
+  const assignViewportRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      localViewportRef.current = node;
+
+      if (viewportRef) {
+        (viewportRef as { current: HTMLDivElement | null }).current = node;
+      }
+    },
+    [viewportRef],
+  );
+
+  useEffect(
+    () => () => {
+      clearSettleTimers();
+    },
+    [],
+  );
+
   return (
-    <div className={cn("-mx-3 overflow-visible px-3 pt-5 pb-10", className)}>
+    <div
+      className={cn(
+        "discover-horizontal-rail -mx-3 overflow-visible px-3 pt-5 pb-10",
+        className,
+      )}
+      data-scroll-state={scrollState}
+    >
       <div
-        ref={viewportRef}
+        ref={assignViewportRef}
+        onPointerDown={beginInteraction}
+        onPointerUp={scheduleDeferredSettle}
+        onPointerCancel={scheduleDeferredSettle}
+        onPointerLeave={scheduleDeferredSettle}
+        onTouchEnd={scheduleDeferredSettle}
+        onWheel={handleWheel}
+        onScroll={handleScroll}
         className={cn(
-          "snap-x snap-proximity overflow-x-auto overflow-y-hidden pt-2 pb-10 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden",
+          "discover-horizontal-rail-viewport snap-x snap-proximity overflow-x-auto overflow-y-hidden pt-2 pb-10 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden",
           viewportClassName,
         )}
       >
         <div
           className={cn(
-            "flex min-w-full items-stretch gap-4 px-3",
+            "discover-horizontal-rail-content flex min-w-full items-stretch gap-4 px-3",
             contentClassName,
           )}
         >
@@ -1184,6 +1386,7 @@ function DiscoverSectionRail({
     id: string;
     title: string;
     subtitle?: string;
+    origin?: "personal" | "market";
     items: DiscoverItem[];
   };
   onQueueTrack: (track: Track) => Promise<void>;
@@ -1228,7 +1431,9 @@ function DiscoverSectionRail({
     <section className="space-y-4">
       <SectionHeading
         icon={
-          hasCollectionItems ? (
+          section.origin === "personal" ? (
+            <Sparkles className="h-4 w-4" />
+          ) : hasCollectionItems ? (
             <Layers3 className="h-4 w-4" />
           ) : (
             <Music2 className="h-4 w-4" />
@@ -1866,7 +2071,7 @@ export const DiscoverView = ({ isMobile = false }: DiscoverViewProps) => {
     >
       <ScrollArea
         className={`min-h-0 flex-1 ${
-          isMobile ? "px-4 pb-[184px] pt-4" : "desktop-scrollbar p-5 xl:p-6"
+          isMobile ? "px-4 pb-6 pt-4" : "desktop-scrollbar p-5 xl:p-6"
         }`}
         maxHeight="none"
       >
@@ -1915,24 +2120,26 @@ export const DiscoverView = ({ isMobile = false }: DiscoverViewProps) => {
             </div>
           </Card>
 
-          <section className="space-y-4">
-            <SectionHeading
-              icon={<Music2 className="h-4 w-4" />}
-              title="本站熱門點播"
-              subtitle="用冠軍焦點卡搭配連續名次列，快速看到站內最常被主動加入的歌曲。"
-            />
-            <TopRequestedRail
-              entries={topRequested}
-              onQueueTrack={handleQueueTrack}
-              onCreateMix={handleCreateMix}
-              onToggleFavorite={handleToggleFavorite}
-              pendingTrackId={pendingTrackId}
-              creatingMixId={creatingMixId}
-              favoriteTrackIds={favoriteTrackIds}
-              libraryReady={libraryReady}
-              isMobile={isMobile}
-            />
-          </section>
+          {topRequested.length > 0 ? (
+            <section className="space-y-4">
+              <SectionHeading
+                icon={<Music2 className="h-4 w-4" />}
+                title="本站熱門點播"
+                subtitle="用冠軍焦點卡搭配連續名次列，快速看到站內最常被主動加入的歌曲。"
+              />
+              <TopRequestedRail
+                entries={topRequested}
+                onQueueTrack={handleQueueTrack}
+                onCreateMix={handleCreateMix}
+                onToggleFavorite={handleToggleFavorite}
+                pendingTrackId={pendingTrackId}
+                creatingMixId={creatingMixId}
+                favoriteTrackIds={favoriteTrackIds}
+                libraryReady={libraryReady}
+                isMobile={isMobile}
+              />
+            </section>
+          ) : null}
 
           <section className="space-y-4">
             <SectionHeading

--- a/frontend/src/components/discover/MusicVideoHeroRail.tsx
+++ b/frontend/src/components/discover/MusicVideoHeroRail.tsx
@@ -166,7 +166,7 @@ function FeaturedVideoCard({
           destination.onOpen ? "cursor-pointer" : "cursor-default",
         )}
       >
-        <div className="discover-rail-card-media relative h-full min-h-[240px] overflow-hidden bg-[var(--surface-subtle)] aspect-[16/9] sm:min-h-[280px] lg:min-h-[320px] xl:aspect-auto">
+        <div className="discover-rail-card-media relative h-full min-h-[220px] overflow-hidden bg-[var(--surface-subtle)] aspect-[16/9] sm:min-h-[280px] lg:min-h-[320px] xl:aspect-auto">
           <MediaArtwork
             item={item}
             preferredQuality={ThumbnailQuality.MAXRES}
@@ -194,7 +194,7 @@ function FeaturedVideoCard({
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/70">
                 Featured Visual
               </p>
-              <h3 className="mt-2 text-[1.7rem] font-semibold leading-tight tracking-tight text-white lg:text-[2.15rem]">
+              <h3 className="mt-2 line-clamp-2 text-[1.35rem] font-semibold leading-tight tracking-tight text-white sm:text-[1.55rem] lg:text-[2.05rem]">
                 {item.title}
               </h3>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-white/82 lg:text-base">

--- a/frontend/src/components/layout/ConnectionStatus.tsx
+++ b/frontend/src/components/layout/ConnectionStatus.tsx
@@ -1,5 +1,4 @@
 import { usePlayerStore } from "@/stores/playerStore";
-import { Badge } from "@/components/ui/badge";
 
 export const ConnectionStatus = () => {
   const connectionStatus = usePlayerStore((state) => state.connectionStatus);
@@ -30,9 +29,11 @@ export const ConnectionStatus = () => {
   return (
     <>
       {/* 桌面版：顯示完整狀態 */}
-      <div className="hidden lg:flex items-center gap-2 rounded-full border border-[color:var(--dynamic-ring)] bg-[var(--surface-subtle)] px-2.5 py-2 shadow-[0_14px_32px_-24px_var(--accent-glow)] transition-[border-color,background-color,box-shadow] duration-300">
-        <span className="text-sm text-[var(--text-secondary)]">狀態</span>
-        <Badge className={config.badgeClassName}>{config.text}</Badge>
+      <div className="hidden h-10 shrink-0 items-center gap-2 rounded-[var(--app-radius-md)] border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] px-3 text-sm text-[var(--text-secondary)] shadow-[0_14px_32px_-26px_var(--accent-glow)] transition-[border-color,background-color,box-shadow] duration-300 lg:flex">
+        <span
+          className={`h-2.5 w-2.5 rounded-full transition-colors ${config.dotClassName}`}
+        />
+        <span className="font-medium">{config.text}</span>
       </div>
 
       {/* 手機版：僅顯示指示圓點 */}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -153,6 +153,7 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
   const [isReleaseNotesLoading, setIsReleaseNotesLoading] = useState(false);
   const [releaseNotesError, setReleaseNotesError] = useState<string | null>(null);
   const [isVersionDialogOpen, setIsVersionDialogOpen] = useState(false);
+  const [hasUnseenReleaseNotes, setHasUnseenReleaseNotes] = useState(false);
   const [selectedReleaseVersion, setSelectedReleaseVersion] = useState(
     frontendAppMetadata.appVersion,
   );
@@ -233,6 +234,10 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
   ) {
     setSelectedReleaseVersion(version);
     setActiveReleaseCategory("all");
+    if (currentReleaseNotes?.version) {
+      markReleaseNotesAsSeen(currentReleaseNotes.version);
+      setHasUnseenReleaseNotes(false);
+    }
     setIsVersionDialogOpen(true);
   }
 
@@ -306,21 +311,7 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
       return;
     }
 
-    if (hasSeenReleaseNotes(currentReleaseNotes.version)) {
-      return;
-    }
-
-    markReleaseNotesAsSeen(currentReleaseNotes.version);
-    const versionToOpen = currentReleaseNotes.version;
-    const openTimer = window.setTimeout(() => {
-      setSelectedReleaseVersion(versionToOpen);
-      setActiveReleaseCategory("all");
-      setIsVersionDialogOpen(true);
-    }, 0);
-
-    return () => {
-      window.clearTimeout(openTimer);
-    };
+    setHasUnseenReleaseNotes(!hasSeenReleaseNotes(currentReleaseNotes.version));
   }, [currentReleaseNotes]);
 
   const renderVersionBadgeButton = (className?: string) => (
@@ -331,33 +322,44 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
       title={versionTooltip}
       aria-label="查看版本資訊"
     >
-      <Badge variant={versionBadgeVariant}>v{frontendAppMetadata.appVersion}</Badge>
+      <Badge
+        variant={versionBadgeVariant}
+        className={cn(
+          "gap-1.5 border border-transparent",
+          hasUnseenReleaseNotes &&
+            "border-[color:var(--dynamic-ring)] shadow-[0_12px_26px_-20px_var(--accent-glow)]",
+        )}
+      >
+        v{frontendAppMetadata.appVersion}
+        {hasUnseenReleaseNotes ? (
+          <span className="h-1.5 w-1.5 rounded-full bg-[var(--accent)]" />
+        ) : null}
+      </Badge>
     </button>
   );
 
   return (
     <>
-      <header className="border-b border-[color:var(--surface-border)] bg-[color:var(--surface-subtle)]/90 px-4 py-3 backdrop-blur-xl lg:px-6 lg:py-4">
-        <div className="mx-auto flex max-w-[1480px] items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <div className="hidden h-11 w-11 items-center justify-center rounded-2xl border border-[color:var(--surface-border)] bg-[var(--accent-soft)] text-[var(--accent)] shadow-sm lg:flex">
+      <header className="border-b border-[color:var(--surface-border)] bg-[color:var(--surface-overlay)] px-4 py-2.5 backdrop-blur-xl lg:px-5 lg:py-3">
+        <div className="mx-auto flex max-w-[1480px] items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2.5">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--app-radius-md)] border border-[color:var(--surface-border)] bg-[var(--accent-soft)] text-[var(--accent)] shadow-sm">
               <Music2 className="h-5 w-5" />
             </div>
-            <div>
+            <div className="min-w-0">
               <div className="flex items-center gap-2">
-                <h1 className="text-xl font-bold tracking-tight text-[var(--text-primary)] lg:text-[1.9rem]">
-                  <span className="lg:hidden">🎵</span>{" "}
+                <h1 className="truncate text-lg font-bold tracking-tight text-[var(--text-primary)] lg:text-2xl">
                   <span className="hidden sm:inline">YouTube Music Bot</span>
                 </h1>
                 {renderVersionBadgeButton("hidden sm:inline-flex")}
               </div>
-              <p className="hidden text-sm text-[var(--text-secondary)] lg:block">
+              <p className="hidden text-xs text-[var(--text-secondary)] xl:block">
                 Desktop jukebox with synced lyrics and live queue
               </p>
             </div>
           </div>
 
-          <div className="hidden w-[392px] grid-cols-3 items-center rounded-[24px] border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] p-1 lg:grid">
+          <div className="hidden w-[352px] shrink-0 grid-cols-3 items-center rounded-[var(--app-radius-lg)] border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] p-1 lg:grid xl:w-[392px]">
             {desktopModes.map((mode) => {
               const Icon = mode.icon;
 
@@ -367,7 +369,7 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
                   type="button"
                   onClick={() => setDesktopMode(mode.id)}
                   className={cn(
-                    "inline-flex h-12 min-w-0 items-center justify-center gap-2 rounded-[18px] px-4 text-sm font-semibold leading-none transition-colors",
+                    "inline-flex h-10 min-w-0 items-center justify-center gap-2 rounded-[var(--app-radius-md)] px-3 text-sm font-semibold leading-none transition-colors xl:h-11 xl:px-4",
                     desktopMode === mode.id
                       ? "bg-[var(--surface-elevated)] text-[var(--text-primary)] shadow-[0_12px_24px_-20px_var(--accent-glow)]"
                       : "text-[var(--text-secondary)]",
@@ -380,11 +382,11 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
             })}
           </div>
 
-          <div className="flex items-center gap-2 lg:flex-1 lg:justify-end lg:gap-4">
+          <div className="flex items-center gap-2 lg:min-w-0 lg:flex-1 lg:justify-end">
             <button
               type="button"
               onClick={onSearchClick}
-              className="desktop-command-button hidden min-w-[260px] items-center justify-between rounded-2xl border px-4 py-3 text-left transition-transform duration-200 hover:-translate-y-0.5 lg:flex"
+              className="desktop-command-button hidden min-w-[220px] max-w-[260px] flex-1 items-center justify-between rounded-[var(--app-radius-lg)] border px-3 py-2.5 text-left transition-transform duration-200 hover:-translate-y-0.5 lg:flex xl:min-w-[260px] xl:px-4"
             >
               <span className="flex items-center gap-3 text-[var(--text-primary)]">
                 <Search className="h-4 w-4 text-[var(--text-secondary)]" />
@@ -399,7 +401,7 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
               href="https://github.com/bs10081/youtube-music-bot"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex h-10 w-10 items-center justify-center rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--app-radius-md)] border border-[color:var(--surface-border)] bg-[var(--surface-subtle)] text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"
               aria-label="前往 GitHub 專案"
             >
               <Github className="h-5 w-5" />
@@ -436,75 +438,77 @@ export const Header = ({ onSearchClick }: HeaderProps) => {
                         <History className="h-4 w-4 text-[var(--accent)]" />
                         <span>版本歷史</span>
                       </div>
-                      <div className="mt-4 space-y-2">
-                        {isReleaseNotesLoading && releaseHistory.length === 0 ? (
-                          <div className="flex items-center gap-2 rounded-[22px] border border-[color:var(--surface-border)] bg-[var(--surface-elevated)] px-4 py-3 text-sm text-[var(--text-secondary)]">
-                            <Loader2 className="h-4 w-4 animate-spin text-[var(--accent)]" />
-                            正在載入 GitHub 版本歷史...
-                          </div>
-                        ) : null}
+                      <ScrollArea className="mt-4 pr-1 lg:max-h-[390px]">
+                        <div className="space-y-2">
+                          {isReleaseNotesLoading && releaseHistory.length === 0 ? (
+                            <div className="flex items-center gap-2 rounded-[22px] border border-[color:var(--surface-border)] bg-[var(--surface-elevated)] px-4 py-3 text-sm text-[var(--text-secondary)]">
+                              <Loader2 className="h-4 w-4 animate-spin text-[var(--accent)]" />
+                              正在載入 GitHub 版本歷史...
+                            </div>
+                          ) : null}
 
-                        {!isReleaseNotesLoading &&
-                        releaseHistory.length === 0 &&
-                        releaseNotesError ? (
-                          <div className="rounded-[22px] border border-[#f1d5ca] bg-[#fff4ef] px-4 py-3 text-sm leading-6 text-[#a95536]">
-                            {releaseNotesError}
-                          </div>
-                        ) : null}
+                          {!isReleaseNotesLoading &&
+                          releaseHistory.length === 0 &&
+                          releaseNotesError ? (
+                            <div className="rounded-[22px] border border-[#f1d5ca] bg-[#fff4ef] px-4 py-3 text-sm leading-6 text-[#a95536]">
+                              {releaseNotesError}
+                            </div>
+                          ) : null}
 
-                        {releaseHistory.map((entry) => {
-                          const isActive = entry.version === selectedReleaseNotes?.version;
-                          const isCurrent = entry.version === currentReleaseNotes?.version;
+                          {releaseHistory.map((entry) => {
+                            const isActive = entry.version === selectedReleaseNotes?.version;
+                            const isCurrent = entry.version === currentReleaseNotes?.version;
 
-                          return (
-                            <button
-                              key={entry.version}
-                              type="button"
-                              onClick={() => {
-                                setSelectedReleaseVersion(entry.version);
-                                setActiveReleaseCategory("all");
-                              }}
-                              className={cn(
-                                "w-full rounded-[22px] border px-4 py-3 text-left transition-all",
-                                isActive
-                                  ? "border-[var(--accent)]/20 bg-[var(--surface-elevated)] shadow-[0_18px_38px_-30px_var(--accent-glow)]"
-                                  : "border-[color:var(--surface-border)] bg-[var(--surface-subtle)]/70 hover:bg-[var(--surface-muted)]",
-                              )}
-                            >
-                              <div className="flex flex-wrap items-center gap-2">
-                                <p className="text-sm font-semibold text-[var(--text-primary)]">
-                                  v{entry.version}
-                                </p>
-                                {isCurrent ? (
-                                  <span className="inline-flex items-center rounded-full bg-[var(--accent-soft)] px-2 py-1 text-[10px] font-semibold text-[var(--accent)]">
-                                    目前版本
+                            return (
+                              <button
+                                key={entry.version}
+                                type="button"
+                                onClick={() => {
+                                  setSelectedReleaseVersion(entry.version);
+                                  setActiveReleaseCategory("all");
+                                }}
+                                className={cn(
+                                  "w-full rounded-[22px] border px-4 py-3 text-left transition-all",
+                                  isActive
+                                    ? "border-[var(--accent)]/20 bg-[var(--surface-elevated)] shadow-[0_18px_38px_-30px_var(--accent-glow)]"
+                                    : "border-[color:var(--surface-border)] bg-[var(--surface-subtle)]/70 hover:bg-[var(--surface-muted)]",
+                                )}
+                              >
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <p className="text-sm font-semibold text-[var(--text-primary)]">
+                                    v{entry.version}
+                                  </p>
+                                  {isCurrent ? (
+                                    <span className="inline-flex items-center rounded-full bg-[var(--accent-soft)] px-2 py-1 text-[10px] font-semibold text-[var(--accent)]">
+                                      目前版本
+                                    </span>
+                                  ) : null}
+                                  <span
+                                    className={cn(
+                                      "inline-flex items-center rounded-full border px-2 py-1 text-[10px] font-semibold",
+                                      entry.status === "preview"
+                                        ? "border-[#d4ebdc] bg-[#eef9f2] text-[#156c4f]"
+                                        : "border-[color:var(--surface-border)] bg-[var(--surface-elevated)] text-[var(--text-secondary)]",
+                                    )}
+                                  >
+                                    {getReleaseStatusLabel(entry.status)}
                                   </span>
-                                ) : null}
-                                <span
-                                  className={cn(
-                                    "inline-flex items-center rounded-full border px-2 py-1 text-[10px] font-semibold",
-                                    entry.status === "preview"
-                                      ? "border-[#d4ebdc] bg-[#eef9f2] text-[#156c4f]"
-                                      : "border-[color:var(--surface-border)] bg-[var(--surface-elevated)] text-[var(--text-secondary)]",
-                                  )}
-                                >
-                                  {getReleaseStatusLabel(entry.status)}
-                                </span>
-                              </div>
-                              <p className="mt-2 text-sm font-medium leading-6 text-[var(--text-primary)]">
-                                {entry.title}
-                              </p>
-                              <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-muted)]">
-                                <span className="inline-flex items-center gap-1.5">
-                                  <CalendarDays className="h-3.5 w-3.5" />
-                                  {formatReleaseDate(entry.publishedAt)}
-                                </span>
-                                <span>{countReleaseItems(entry)} 條更新</span>
-                              </div>
-                            </button>
-                          );
-                        })}
-                      </div>
+                                </div>
+                                <p className="mt-2 text-sm font-medium leading-6 text-[var(--text-primary)]">
+                                  {entry.title}
+                                </p>
+                                <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-muted)]">
+                                  <span className="inline-flex items-center gap-1.5">
+                                    <CalendarDays className="h-3.5 w-3.5" />
+                                    {formatReleaseDate(entry.publishedAt)}
+                                  </span>
+                                  <span>{countReleaseItems(entry)} 條更新</span>
+                                </div>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </ScrollArea>
                     </div>
 
                     <div className="surface-subtle rounded-[28px] border border-[color:var(--surface-border)] p-4">

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -18,12 +18,12 @@ export const MainLayout = ({
       <ArtworkThemeBackdrop theme={artworkTheme} />
       <div className="relative z-10 flex h-screen flex-col overflow-hidden">
         <Header onSearchClick={onSearchClick} />
-        <main className="flex-1 overflow-hidden min-h-0">
+        <main className="min-h-0 flex-1 overflow-hidden pb-[var(--mobile-bottom-stack)] lg:pb-0">
           {/* 桌面版：有 padding 和 max-width */}
-          <div className="mx-auto hidden h-full min-h-0 max-w-[1480px] px-4 py-4 lg:block xl:px-6 xl:py-5">
+          <div className="mx-auto hidden h-full min-h-0 max-w-[1480px] px-[var(--app-space-edge)] py-4 lg:block xl:py-5">
             {children}
           </div>
-          {/* 手機版：全高度 */}
+          {/* 手機版：內容區避開底部迷你播放器與 TabBar */}
           <div className="h-full lg:hidden">{children}</div>
         </main>
       </div>

--- a/frontend/src/components/library/LibraryView.tsx
+++ b/frontend/src/components/library/LibraryView.tsx
@@ -452,7 +452,7 @@ export const LibraryView = ({ isMobile = false }: LibraryViewProps) => {
   );
 
   const contentClassName = isMobile
-    ? "h-full w-full px-4 pb-[176px] pt-4"
+    ? "h-full w-full px-4 pb-6 pt-4"
     : "h-full w-full";
 
   return (
@@ -650,7 +650,7 @@ const DesktopLibraryHome = ({
       </div>
     </Card>
 
-    <div className="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(320px,0.85fr)]">
+    <div className="grid items-start gap-6 2xl:grid-cols-[minmax(0,0.95fr)_minmax(320px,0.85fr)]">
       <SavedMixPanel
         savedMixes={savedMixes}
         onReplayMix={onReplayMix}
@@ -1103,7 +1103,7 @@ const SavedMixPanel = ({
   <Card
     className={cn(
       "surface-card rounded-[30px] p-5",
-      !mobile && "flex h-full min-h-0 flex-col",
+      !mobile && "flex min-h-0 flex-col",
     )}
   >
     <div className="mb-4 shrink-0">
@@ -1113,8 +1113,8 @@ const SavedMixPanel = ({
       </p>
     </div>
     <ScrollArea
-      className={cn("w-full", !mobile && "min-h-0 flex-1 pr-1")}
-      maxHeight={mobile ? "34vh" : undefined}
+      className={cn("w-full", !mobile && "min-h-0 pr-1")}
+      maxHeight={mobile ? "34vh" : "42vh"}
     >
       <div className="grid gap-3">
         {savedMixes.length === 0 ? (

--- a/frontend/src/components/mobile/MobileContent.tsx
+++ b/frontend/src/components/mobile/MobileContent.tsx
@@ -147,7 +147,7 @@ export const MobileContent = () => {
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col pb-[168px] lg:hidden">
+    <div className="flex h-full min-h-0 flex-col lg:hidden">
       <form onSubmit={handleSearch} className="shrink-0 px-4 py-4">
         <div className="surface-card relative rounded-[28px] border p-3">
           <Input
@@ -192,7 +192,7 @@ export const MobileContent = () => {
             <Spinner size="lg" />
           </div>
         ) : searchResults.length > 0 ? (
-          <div className="space-y-3 pb-4">
+          <div className="space-y-3 pb-6">
             {searchResults.map((result) => (
               <SearchResultItem
                 key={`${result.kind}:${result.id}`}

--- a/frontend/src/components/mobile/MobileNowPlayingSheet.tsx
+++ b/frontend/src/components/mobile/MobileNowPlayingSheet.tsx
@@ -7,6 +7,7 @@ import { ProgressBar } from "@/components/player/ProgressBar";
 import { PlaybackControls } from "@/components/player/PlaybackControls";
 import { VolumeControl } from "@/components/player/VolumeControl";
 import { CrossfadeControl } from "@/components/player/CrossfadeControl";
+import { VolumeNormalizationControl } from "@/components/player/VolumeNormalizationControl";
 import { LyricsDisplay } from "@/components/lyrics/LyricsDisplay";
 import { QueueSection } from "@/components/queue/QueueSection";
 import { useAppUiStore } from "@/stores/appUiStore";
@@ -189,6 +190,8 @@ export const MobileNowPlayingSheet = () => {
                 </div>
 
                 <CrossfadeControl compact />
+
+                <VolumeNormalizationControl compact />
 
                 <VolumeControl className="max-w-none" />
               </div>

--- a/frontend/src/components/mobile/TabBar.tsx
+++ b/frontend/src/components/mobile/TabBar.tsx
@@ -1,4 +1,5 @@
 import { usePlayerStore } from "@/stores/playerStore";
+import { Compass, LibraryBig, Search } from "lucide-react";
 
 export const TabBar = () => {
   const activeTab = usePlayerStore((state) => state.mobileActiveTab);
@@ -8,71 +9,29 @@ export const TabBar = () => {
     {
       id: "search" as const,
       label: "搜尋",
-      icon: (
-        <svg
-          className="w-6 h-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-          />
-        </svg>
-      ),
+      icon: <Search className="h-5 w-5" />,
     },
     {
       id: "discover" as const,
       label: "Discover",
-      icon: (
-        <svg
-          className="w-6 h-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M12 3l7 4v5c0 5-3.5 8.5-7 9-3.5-.5-7-4-7-9V7l7-4zm0 5l2.5 2.5L12 18l-2.5-7.5L12 8z"
-          />
-        </svg>
-      ),
+      icon: <Compass className="h-5 w-5" />,
     },
     {
       id: "library" as const,
       label: "資料庫",
-      icon: (
-        <svg
-          className="w-6 h-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-          />
-        </svg>
-      ),
+      icon: <LibraryBig className="h-5 w-5" />,
     },
   ];
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-40 px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] lg:hidden">
-      <div className="surface-card grid min-h-20 grid-cols-3 rounded-[30px] border p-1.5 shadow-[0_22px_44px_-32px_rgba(15,23,42,0.3)]">
+      <div className="surface-card grid min-h-20 grid-cols-3 rounded-[var(--app-radius-xl)] border p-1.5 shadow-[0_22px_44px_-32px_rgba(15,23,42,0.3)]">
         {tabs.map((tab) => (
           <button
             type="button"
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
-            className={`flex min-h-[70px] flex-col items-center justify-center gap-1 rounded-[22px] transition-all ${
+            className={`flex min-h-[70px] flex-col items-center justify-center gap-1 rounded-[var(--app-radius-lg)] transition-all ${
               activeTab === tab.id
                 ? "bg-[var(--surface-elevated)] text-[var(--accent)] shadow-[0_14px_28px_-24px_var(--accent-glow)]"
                 : "text-[var(--text-secondary)]"

--- a/frontend/src/components/player/MiniPlayer.tsx
+++ b/frontend/src/components/player/MiniPlayer.tsx
@@ -6,6 +6,7 @@ import { usePlayerStore } from "@/stores/playerStore";
 import { useAppUiStore } from "@/stores/appUiStore";
 import { api } from "@/services/api";
 import { RadioToggleButton } from "./RadioToggleButton";
+import { Music2, Pause, Play, SkipForward } from "lucide-react";
 
 export const MiniPlayer = () => {
   const currentTrack = usePlayerStore(
@@ -77,10 +78,10 @@ export const MiniPlayer = () => {
 
   return (
     <div
-      className="fixed bottom-[104px] left-0 right-0 z-50 px-3 lg:hidden"
+      className="fixed bottom-[calc(6.5rem+env(safe-area-inset-bottom))] left-0 right-0 z-50 px-3 lg:hidden"
     >
       <div
-        className="surface-card overflow-hidden rounded-[28px] border bg-[var(--surface-elevated)]/95 transition-colors"
+        className="surface-card overflow-hidden rounded-[var(--app-radius-xl)] border bg-[var(--surface-elevated)]/95 transition-colors"
         onClick={() => {
           if (currentTrack) {
             setMobileNowPlayingView("player");
@@ -110,7 +111,7 @@ export const MiniPlayer = () => {
                 src={currentTrack.thumbnail}
                 alt={currentTrack.title}
                 size="sm"
-                className="rounded-[16px]"
+                className="rounded-[var(--app-radius-md)]"
               />
 
               <div className="min-w-0 flex-1">
@@ -150,21 +151,9 @@ export const MiniPlayer = () => {
                   {isLoading || isLoadingTrack ? (
                     <Spinner size="sm" />
                   ) : isPlaying ? (
-                    <svg
-                      className="h-5 w-5"
-                      fill="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
-                    </svg>
+                    <Pause className="h-5 w-5" />
                   ) : (
-                    <svg
-                      className="h-5 w-5"
-                      fill="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path d="M8 5v14l11-7z" />
-                    </svg>
+                    <Play className="h-5 w-5" />
                   )}
                 </Button>
 
@@ -176,26 +165,14 @@ export const MiniPlayer = () => {
                   title="下一首"
                   className="h-9 w-9 rounded-full px-0"
                 >
-                  <svg
-                    className="h-5 w-5"
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path d="M6 4l10 8-10 8V4zm12 0v16h2V4h-2z" />
-                  </svg>
+                  <SkipForward className="h-5 w-5" />
                 </Button>
               </div>
             </>
           ) : (
             <div className="flex flex-1 items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-[16px] bg-[var(--surface-muted)]">
-                <svg
-                  className="h-6 w-6 text-[var(--text-muted)]"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
-                </svg>
+              <div className="flex h-10 w-10 items-center justify-center rounded-[var(--app-radius-md)] bg-[var(--surface-muted)]">
+                <Music2 className="h-5 w-5 text-[var(--text-muted)]" />
               </div>
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium text-[var(--text-secondary)]">

--- a/frontend/src/components/player/NowPlaying.tsx
+++ b/frontend/src/components/player/NowPlaying.tsx
@@ -61,11 +61,11 @@ export const NowPlaying = ({
         <div className="flex flex-col items-center gap-6 text-center lg:items-start lg:text-left">
           <Avatar
             size="lg"
-            className="h-44 w-44 rounded-[28px] border border-[color:var(--dynamic-ring)] bg-[color:color-mix(in_srgb,var(--surface-elevated)_84%,var(--accent-soft)_16%)]"
+            className="h-44 w-44 rounded-[var(--app-radius-xl)] border border-[color:var(--dynamic-ring)] bg-[color:color-mix(in_srgb,var(--surface-elevated)_84%,var(--accent-soft)_16%)]"
             fallback={<Sparkles className="h-14 w-14 text-[var(--text-muted)]" />}
           />
           <div className="space-y-3">
-            <span className="inline-flex rounded-full border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent)]">
+            <span className="inline-flex rounded-[var(--app-radius-sm)] border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--accent)]">
               Preparing
             </span>
             <div>
@@ -87,11 +87,11 @@ export const NowPlaying = ({
           <div className="flex items-start gap-4">
             <Avatar
               size="lg"
-              className="h-28 w-28 shrink-0 rounded-[24px] border border-[color:var(--dynamic-ring)] bg-[color:color-mix(in_srgb,var(--surface-elevated)_84%,var(--accent-soft)_16%)]"
+              className="h-28 w-28 shrink-0 rounded-[var(--app-radius-lg)] border border-[color:var(--dynamic-ring)] bg-[color:color-mix(in_srgb,var(--surface-elevated)_84%,var(--accent-soft)_16%)]"
               fallback={<Sparkles className="h-10 w-10 text-[var(--text-muted)]" />}
             />
             <div className="min-w-0 space-y-3">
-              <span className="inline-flex rounded-full border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent)]">
+              <span className="inline-flex rounded-[var(--app-radius-sm)] border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--accent)]">
                 Ready
               </span>
               <div className="space-y-2">
@@ -132,17 +132,17 @@ export const NowPlaying = ({
     return (
       <div className="mx-auto flex w-full max-w-[720px] flex-col items-center justify-center gap-7 text-center lg:gap-8">
         <div className="relative">
-          <div className="absolute inset-4 rounded-[28px] bg-[var(--accent-soft)] blur-3xl opacity-80" />
+          <div className="absolute inset-5 rounded-[var(--app-radius-xl)] bg-[var(--accent-soft)] blur-3xl opacity-45" />
           <Avatar
             size="lg"
-            className="relative h-40 w-40 rounded-[28px] border border-[color:var(--dynamic-ring)] bg-[color:color-mix(in_srgb,var(--surface-elevated)_84%,var(--accent-soft)_16%)] shadow-[0_22px_48px_-28px_rgba(15,23,42,0.28)] lg:h-48 lg:w-48"
+            className="relative h-40 w-40 rounded-[var(--app-radius-xl)] border border-[color:var(--dynamic-ring)] bg-[color:color-mix(in_srgb,var(--surface-elevated)_84%,var(--accent-soft)_16%)] shadow-[0_22px_48px_-28px_rgba(15,23,42,0.28)] lg:h-48 lg:w-48"
             fallback={
               <Sparkles className="h-14 w-14 text-[var(--text-muted)] lg:h-16 lg:w-16" />
             }
           />
         </div>
         <div className="flex max-w-[640px] flex-col items-center gap-4">
-          <span className="inline-flex rounded-full border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent)]">
+          <span className="inline-flex rounded-[var(--app-radius-sm)] border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--accent)]">
             Ready to play
           </span>
           <div className="space-y-3">
@@ -218,7 +218,7 @@ export const NowPlaying = ({
           isSidebarCompact && "space-y-3 text-left",
         )}
       >
-        <span className="inline-flex rounded-full border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--text-primary)]">
+        <span className="inline-flex rounded-[var(--app-radius-sm)] border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-primary)]">
           {isPlaying ? "Now Playing" : "Paused"}
         </span>
         <div className="min-w-0 space-y-2">

--- a/frontend/src/components/player/PlayerSection.tsx
+++ b/frontend/src/components/player/PlayerSection.tsx
@@ -4,6 +4,7 @@ import { ProgressBar } from "./ProgressBar";
 import { PlaybackControls } from "./PlaybackControls";
 import { VolumeControl } from "./VolumeControl";
 import { CrossfadeControl } from "./CrossfadeControl";
+import { VolumeNormalizationControl } from "./VolumeNormalizationControl";
 import { usePlayerStore } from "@/stores/playerStore";
 import { cn } from "@/lib/utils";
 import { OpenAlbumButton } from "@/components/album/OpenAlbumButton";
@@ -88,7 +89,7 @@ export const PlayerSection = ({
               >
                 <div
                   className={cn(
-                    "surface-subtle rounded-[28px] border border-[color:var(--dynamic-ring)]",
+                    "surface-subtle rounded-[var(--app-radius-xl)] border border-[color:var(--dynamic-ring)]",
                     isSidebarShell ? "p-4" : "p-4 xl:p-5",
                   )}
                 >
@@ -121,11 +122,13 @@ export const PlayerSection = ({
                       </p>
                       <CrossfadeControl />
                     </div>
+
+                    <VolumeNormalizationControl compact />
                   </div>
                 </div>
                 <div
                   className={cn(
-                    "surface-subtle rounded-[24px] border border-[color:var(--dynamic-ring)]",
+                    "surface-subtle rounded-[var(--app-radius-lg)] border border-[color:var(--dynamic-ring)]",
                     "p-4",
                   )}
                 >
@@ -139,7 +142,7 @@ export const PlayerSection = ({
                         alt={nextTrack.title}
                         size="md"
                         thumbnailQuality="sddefault"
-                        className="rounded-2xl"
+                        className="rounded-[var(--app-radius-md)]"
                       />
                       <div className="min-w-0 flex-1">
                         <p
@@ -168,7 +171,7 @@ export const PlayerSection = ({
                           </p>
                         ) : null}
                       </div>
-                      <span className="shrink-0 rounded-full border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--text-primary)]">
+                      <span className="shrink-0 rounded-[var(--app-radius-sm)] border border-[color:var(--dynamic-ring)] bg-[color:var(--accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--text-primary)]">
                         {formatTime(nextTrack.duration)}
                       </span>
                     </div>

--- a/frontend/src/components/player/VolumeNormalizationControl.tsx
+++ b/frontend/src/components/player/VolumeNormalizationControl.tsx
@@ -77,10 +77,10 @@ export const VolumeNormalizationControl = ({
             </p>
           </div>
           <p className="text-xs leading-5 text-[var(--text-secondary)]">
-            依照 YouTube 的 loudness dB metadata 壓低偏大的歌曲，讓不同曲目的聽感更穩定。
+            播放時即時平衡響度，大聲與小聲的段落都會貼近一致的聽感。
           </p>
           <p className="text-xs leading-5 text-[var(--text-muted)]">
-            這不會提高主音量，也不會把較安靜的歌曲額外放大。
+            主音量維持由你控制，切換後立即生效、不需重新播放。
           </p>
         </div>
         <Button

--- a/frontend/src/components/search/MobileSearchPage.tsx
+++ b/frontend/src/components/search/MobileSearchPage.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useRef } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
 import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,6 +17,7 @@ import { getCurrentRequester, useLibraryStore } from "@/stores/libraryStore";
 import { api } from "@/services/api";
 import { SearchResultItem } from "./SearchResultItem";
 import type { CollectionSearchResult, Track } from "@/types";
+import { ArrowLeft, Search } from "lucide-react";
 
 const EMPTY_FAVORITES: Array<{ videoId: string }> = [];
 
@@ -63,8 +70,7 @@ export const MobileSearchPage = () => {
     setSearchResults([]);
   };
 
-  const handleSearch = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submitSearch = async () => {
     if (!query.trim()) return;
 
     setIsSearching(true);
@@ -83,6 +89,20 @@ export const MobileSearchPage = () => {
     } finally {
       setIsSearching(false);
     }
+  };
+
+  const handleSearch = (e: FormEvent) => {
+    e.preventDefault();
+    void submitSearch();
+  };
+
+  const handleSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter" || e.nativeEvent.isComposing) {
+      return;
+    }
+
+    e.preventDefault();
+    void submitSearch();
   };
 
   const handleAddToQueue = async (track: Track) => {
@@ -181,32 +201,20 @@ export const MobileSearchPage = () => {
 
   const content = (
     <div
-      className={`fixed inset-0 z-50 bg-white dark:bg-gray-950 ${
+      className={`fixed inset-0 z-50 bg-[var(--page-bottom)] text-[var(--text-primary)] ${
         isMobileSearchOpen ? "mobile-search-enter" : "mobile-search-exit"
       }`}
     >
-      <div className="sticky top-0 z-10 border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950">
+      <div className="sticky top-0 z-10 border-b border-[color:var(--surface-border)] bg-[var(--surface-overlay)] backdrop-blur-xl">
         <div className="flex items-center gap-4 px-4 py-3">
           <button
             onClick={handleClose}
-            className="-ml-2 rounded-lg p-2 text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+            className="-ml-2 rounded-[var(--app-radius-sm)] p-2 text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"
             aria-label="返回"
           >
-            <svg
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
+            <ArrowLeft className="h-6 w-6" />
           </button>
-          <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-50">
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">
             搜尋音樂
           </h1>
         </div>
@@ -219,29 +227,18 @@ export const MobileSearchPage = () => {
               placeholder="搜尋歌曲、藝人或貼上 YouTube 連結..."
               value={query}
               onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
               disabled={isSearching}
-              className="h-12 w-full rounded-xl border-gray-200/64 bg-gray-100 pl-12 pr-4 text-base focus:ring-2 focus:ring-gray-900 dark:border-gray-700/64 dark:bg-gray-800 dark:focus:ring-gray-50"
+              className="h-12 w-full rounded-[var(--app-radius-md)] border-[color:var(--surface-border)] bg-[var(--surface-subtle)] pl-12 pr-4 text-base"
             />
-            <div className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400">
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
+            <div className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
+              <Search className="h-5 w-5" />
             </div>
             {query.trim() && (
               <Button
                 type="submit"
                 disabled={isSearching}
-                className="absolute right-2 top-1/2 h-8 -translate-y-1/2 rounded-lg bg-gradient-to-r from-gray-900 to-gray-700 px-4 text-sm text-white transition-transform duration-200 hover:translate-y-0.5 dark:from-gray-50 dark:to-gray-200 dark:text-gray-900"
+                className="absolute right-2 top-1/2 h-8 -translate-y-1/2 rounded-[var(--app-radius-sm)] px-4 text-sm"
               >
                 {isSearching ? <Spinner size="sm" /> : "搜尋"}
               </Button>

--- a/frontend/src/components/search/SearchInput.tsx
+++ b/frontend/src/components/search/SearchInput.tsx
@@ -1,4 +1,9 @@
-import { forwardRef, useState, type FormEvent } from "react";
+import {
+  forwardRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -14,11 +19,24 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   ({ onSearch, isLoading, className }, ref) => {
     const [query, setQuery] = useState("");
 
-    const handleSubmit = (e: FormEvent) => {
-      e.preventDefault();
+    const submitQuery = () => {
       if (query.trim()) {
         onSearch(query.trim());
       }
+    };
+
+    const handleSubmit = (e: FormEvent) => {
+      e.preventDefault();
+      submitQuery();
+    };
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== "Enter" || e.nativeEvent.isComposing) {
+        return;
+      }
+
+      e.preventDefault();
+      submitQuery();
     };
 
     return (
@@ -32,6 +50,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           placeholder="搜尋歌曲、藝人或貼上 YouTube 連結..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
           disabled={isLoading}
           className="min-w-0 flex-1"
         />

--- a/frontend/src/components/search/SearchSection.tsx
+++ b/frontend/src/components/search/SearchSection.tsx
@@ -46,7 +46,7 @@ export const SearchSection = () => {
       } else {
         showToast({ message: response.error || "搜尋失敗", type: "error" });
       }
-    } catch (error) {
+    } catch {
       showToast({ message: "搜尋發生錯誤", type: "error" });
     } finally {
       setIsSearching(false);
@@ -62,7 +62,7 @@ export const SearchSection = () => {
       } else {
         showToast({ message: response.error || "加入失敗", type: "error" });
       }
-    } catch (error) {
+    } catch {
       showToast({ message: "加入發生錯誤", type: "error" });
     } finally {
       setAddingId(null);
@@ -107,7 +107,7 @@ export const SearchSection = () => {
           type: "error",
         });
       }
-    } catch (error) {
+    } catch {
       showToast({ message: "創建 Mix 發生錯誤", type: "error" });
     } finally {
       setCreatingMixId(null);
@@ -145,7 +145,7 @@ export const SearchSection = () => {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-50">
+        <h2 className="text-xl font-semibold text-[var(--text-primary)]">
           搜尋音樂
         </h2>
       </div>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         className={cn(
           // 基礎樣式
-          "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-xl font-medium transition-all duration-200",
+          "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--app-radius-sm)] font-medium transition-all duration-200",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0",
           "disabled:pointer-events-none disabled:opacity-50",
           // 尺寸

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "surface-card rounded-[28px] border text-[var(--text-primary)]",
+      "surface-card rounded-[var(--app-radius-lg)] border text-[var(--text-primary)]",
       className,
     )}
     {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Dialog as BaseDialog } from "@base-ui/react/dialog";
+import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // Dialog Root
@@ -80,7 +81,7 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
               : [
                   "fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]",
                   "w-full max-w-lg max-h-[85vh] overflow-hidden",
-                  "surface-card rounded-[28px]",
+                  "surface-card rounded-[var(--app-radius-xl)]",
                   "data-[state=open]:animate-in data-[state=closed]:animate-out",
                   "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
                   "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
@@ -163,21 +164,8 @@ const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
       >
         {children || (
           <span className="h-4 w-4">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M18 6 6 18" />
-              <path d="m6 6 12 12" />
-            </svg>
-            <span className="sr-only">Close</span>
+            <X className="h-4 w-4" />
+            <span className="sr-only">關閉</span>
           </span>
         )}
       </BaseDialog.Close>

--- a/frontend/src/components/ui/empty.tsx
+++ b/frontend/src/components/ui/empty.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Inbox } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface EmptyProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -12,31 +13,19 @@ const Empty = React.forwardRef<HTMLDivElement, EmptyProps>(
       <div
         ref={ref}
         className={cn(
-          "flex flex-col items-center justify-center py-12 text-center",
+          "flex flex-col items-center justify-center py-12 text-center text-[var(--text-secondary)]",
           className
         )}
         {...props}
       >
-        <div className="mb-4 rounded-full bg-gray-100 p-4 dark:bg-gray-800">
-          <svg
-            className="h-8 w-8 text-gray-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
-            />
-          </svg>
+        <div className="mb-4 rounded-[var(--app-radius-lg)] border border-[color:var(--dynamic-ring)] bg-[var(--surface-subtle)] p-4 text-[var(--accent)] shadow-[0_16px_34px_-28px_var(--accent-glow)]">
+          <Inbox className="h-8 w-8" />
         </div>
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-50">
+        <h3 className="text-lg font-semibold text-[var(--text-primary)]">
           {title}
         </h3>
         {description && (
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          <p className="mt-1 max-w-md text-sm leading-6 text-[var(--text-secondary)]">
             {description}
           </p>
         )}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         ref={ref}
         className={cn(
-          "flex h-10 w-full rounded-xl border px-3 py-2 text-sm transition-colors",
+          "flex h-10 w-full rounded-[var(--app-radius-sm)] border px-3 py-2 text-sm transition-colors",
           "bg-[var(--surface-subtle)] text-[var(--text-primary)]",
           "placeholder:text-[var(--text-muted)]",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0",

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -11,7 +11,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "desktop-segmented relative inline-flex h-16 items-center justify-center overflow-hidden rounded-[30px] p-1 text-[var(--text-muted)]",
+      "desktop-segmented relative inline-flex h-14 items-center justify-center overflow-hidden rounded-[var(--app-radius-lg)] p-1 text-[var(--text-muted)]",
       className,
     )}
     {...props}
@@ -26,7 +26,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Tab
     ref={ref}
     className={cn(
-      "relative z-10 inline-flex h-full flex-1 items-center justify-center whitespace-nowrap rounded-[24px] px-6 py-3 text-[1.05rem] font-semibold transition-all",
+      "relative z-10 inline-flex h-full flex-1 items-center justify-center whitespace-nowrap rounded-[var(--app-radius-md)] px-5 py-3 text-[1rem] font-semibold transition-all",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0",
       "disabled:pointer-events-none disabled:opacity-50",
       "data-[selected]:text-[var(--text-primary)] data-[selected]:drop-shadow-[0_1px_0_rgba(255,255,255,0.25)]",
@@ -44,7 +44,7 @@ const TabsIndicator = React.forwardRef<
   <TabsPrimitive.Indicator
     ref={ref}
     className={cn(
-      "desktop-segmented-indicator pointer-events-none absolute left-[var(--active-tab-left)] top-[var(--active-tab-top)] z-0 h-[var(--active-tab-height)] w-[var(--active-tab-width)] rounded-[24px] transition-[left,width,height,transform] duration-300",
+      "desktop-segmented-indicator pointer-events-none absolute left-[var(--active-tab-left)] top-[var(--active-tab-top)] z-0 h-[var(--active-tab-height)] w-[var(--active-tab-width)] rounded-[var(--app-radius-md)] transition-[left,width,height,transform] duration-300",
       className,
     )}
     {...props}

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -49,13 +49,16 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
           <div
             key={toast.id}
             className={cn(
-              "pointer-events-auto rounded-lg px-4 py-3 border border-gray-200",
+              "pointer-events-auto rounded-[var(--app-radius-md)] border border-[color:var(--surface-border)] px-4 py-3 shadow-[var(--surface-shadow)] backdrop-blur-xl",
               "animate-in slide-in-from-right-full",
-              toast.type === "success" && "bg-white text-gray-900",
-              toast.type === "error" && "bg-gray-900 text-white",
-              toast.type === "warning" && "bg-white text-gray-900",
+              toast.type === "success" &&
+                "bg-[var(--surface-overlay)] text-[var(--status-success-text)]",
+              toast.type === "error" &&
+                "bg-[var(--surface-overlay)] text-[var(--status-error-text)]",
+              toast.type === "warning" &&
+                "bg-[var(--surface-overlay)] text-[var(--status-warning-text)]",
               (!toast.type || toast.type === "info") &&
-                "bg-white text-gray-900",
+                "bg-[var(--surface-overlay)] text-[var(--text-primary)]",
             )}
           >
             {toast.message}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,20 +49,30 @@
 }
 
 :root {
+  --app-radius-xs: 0.5rem;
+  --app-radius-sm: 0.75rem;
+  --app-radius-md: 1rem;
+  --app-radius-lg: 1.25rem;
+  --app-radius-xl: 1.5rem;
+  --app-space-edge: clamp(1rem, 2.4vw, 1.5rem);
+  --mobile-bottom-stack: calc(11.75rem + env(safe-area-inset-bottom));
   --page-top: #fbfdff;
   --page-bottom: #edf2f8;
   --page-accent: rgba(77, 114, 213, 0.12);
   --surface-elevated: rgba(255, 255, 255, 0.9);
   --surface-muted: rgba(246, 249, 252, 0.8);
   --surface-subtle: rgba(255, 255, 255, 0.72);
+  --surface-overlay: rgba(255, 255, 255, 0.86);
   --surface-border: rgba(148, 163, 184, 0.22);
   --surface-shadow:
-    0 24px 40px -32px rgba(15, 23, 42, 0.18),
-    0 10px 20px -18px rgba(15, 23, 42, 0.1);
-  --surface-shadow-strong: 0 36px 80px -40px rgba(15, 23, 42, 0.32);
+    0 18px 38px -32px rgba(15, 23, 42, 0.2),
+    0 8px 18px -18px rgba(15, 23, 42, 0.12);
+  --surface-shadow-strong:
+    0 28px 72px -46px rgba(15, 23, 42, 0.34),
+    0 14px 34px -30px rgba(15, 23, 42, 0.16);
   --text-primary: #111827;
   --text-secondary: #5b6678;
-  --text-muted: #8a93a5;
+  --text-muted: #6f7a8d;
   --accent: #1f3f92;
   --accent-contrast: #f8fbff;
   --accent-soft: rgba(54, 84, 176, 0.14);
@@ -82,12 +92,20 @@
 }
 
 .dark {
+  --app-radius-xs: 0.5rem;
+  --app-radius-sm: 0.75rem;
+  --app-radius-md: 1rem;
+  --app-radius-lg: 1.25rem;
+  --app-radius-xl: 1.5rem;
+  --app-space-edge: clamp(1rem, 2.4vw, 1.5rem);
+  --mobile-bottom-stack: calc(11.75rem + env(safe-area-inset-bottom));
   --page-top: #0d1320;
   --page-bottom: #070b12;
   --page-accent: rgba(86, 131, 255, 0.18);
   --surface-elevated: rgba(16, 22, 34, 0.92);
   --surface-muted: rgba(20, 27, 40, 0.86);
   --surface-subtle: rgba(30, 38, 56, 0.74);
+  --surface-overlay: rgba(12, 18, 29, 0.9);
   --surface-border: rgba(132, 148, 182, 0.18);
   --surface-shadow:
     0 28px 46px -34px rgba(0, 0, 0, 0.48),
@@ -119,8 +137,8 @@ body {
   margin: 0;
   font-family: system-ui, -apple-system, sans-serif;
   background:
-    radial-gradient(circle at top left, var(--page-accent), transparent 36%),
-    radial-gradient(circle at bottom right, var(--page-accent), transparent 28%),
+    radial-gradient(circle at 16% 10%, var(--page-accent), transparent 30%),
+    radial-gradient(circle at 78% 86%, var(--page-accent), transparent 26%),
     linear-gradient(180deg, var(--page-top) 0%, var(--page-bottom) 100%);
   color: var(--text-primary);
   transition: color 220ms ease;
@@ -160,7 +178,7 @@ body {
     linear-gradient(180deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.04) 28%, rgba(255, 255, 255, 0.1) 100%),
     radial-gradient(circle at top center, rgba(255, 255, 255, 0.18), transparent 34%);
   mix-blend-mode: screen;
-  opacity: 0.5;
+  opacity: 0.38;
 }
 
 .artwork-crossfade-previous,
@@ -244,7 +262,7 @@ body {
   background: var(--surface-elevated);
   border-color: var(--surface-border);
   box-shadow: var(--surface-shadow);
-  backdrop-filter: blur(18px);
+  backdrop-filter: blur(16px);
   background-clip: padding-box;
   transition:
     background 360ms ease,
@@ -254,10 +272,9 @@ body {
 
 .surface-card-strong {
   background:
-    radial-gradient(circle at top center, var(--player-tint), transparent 44%),
-    radial-gradient(circle at bottom right, var(--accent-soft), transparent 40%),
-    linear-gradient(180deg, color-mix(in srgb, var(--surface-elevated) 92%, white 8%) 0%, var(--surface-elevated) 100%);
-  border-color: color-mix(in srgb, var(--surface-border) 76%, var(--dynamic-ring) 24%);
+    radial-gradient(circle at 18% 0%, var(--player-tint), transparent 34%),
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-elevated) 94%, white 6%) 0%, var(--surface-elevated) 100%);
+  border-color: color-mix(in srgb, var(--surface-border) 82%, var(--dynamic-ring) 18%);
   box-shadow: var(--surface-shadow-strong);
   background-clip: padding-box;
   transition:
@@ -266,8 +283,21 @@ body {
     box-shadow 360ms ease;
 }
 
+.discover-horizontal-rail-viewport {
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scroll-behavior: auto;
+}
+
+.discover-horizontal-rail[data-scroll-state="active"] .discover-horizontal-rail-viewport,
+.discover-horizontal-rail[data-scroll-state="settling"] .discover-horizontal-rail-viewport {
+  scroll-snap-type: none;
+}
+
 .discover-rail-item {
   --discover-rail-emphasis: 0;
+  --discover-rail-layout-emphasis: var(--discover-rail-emphasis);
+  --discover-rail-visual-emphasis: var(--discover-rail-emphasis);
   --discover-rail-base-rem: 19.25;
   --discover-rail-grow-rem: 6.25;
   --discover-rail-max-size: 82vw;
@@ -280,7 +310,7 @@ body {
       calc(
         (
             var(--discover-rail-base-rem) +
-              (var(--discover-rail-grow-rem) * var(--discover-rail-emphasis))
+              (var(--discover-rail-grow-rem) * var(--discover-rail-layout-emphasis))
           ) * 1rem
       )
     );
@@ -290,18 +320,27 @@ body {
       calc(
         (
             var(--discover-rail-base-rem) +
-              (var(--discover-rail-grow-rem) * var(--discover-rail-emphasis))
+              (var(--discover-rail-grow-rem) * var(--discover-rail-layout-emphasis))
           ) * 1rem
       )
     );
-  padding-bottom: calc(2.25rem + (var(--discover-rail-emphasis) * 0.625rem));
-  margin-inline-end: calc(0.125rem + (var(--discover-rail-emphasis) * 1rem));
+  padding-bottom: calc(2.25rem + (var(--discover-rail-layout-emphasis) * 0.625rem));
+  margin-inline-end: calc(0.125rem + (var(--discover-rail-layout-emphasis) * 1rem));
   z-index: 0;
   transition:
     flex-basis 260ms cubic-bezier(0.22, 1, 0.36, 1),
     width 260ms cubic-bezier(0.22, 1, 0.36, 1),
     margin-inline-end 260ms cubic-bezier(0.22, 1, 0.36, 1),
     padding-bottom 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.discover-horizontal-rail[data-scroll-state="active"] .discover-rail-item,
+.discover-horizontal-rail[data-scroll-state="settling"] .discover-rail-item {
+  --discover-rail-layout-emphasis: var(
+    --discover-rail-frozen-emphasis,
+    var(--discover-rail-emphasis)
+  );
+  transition: none;
 }
 
 .discover-rail-item-track {
@@ -318,8 +357,8 @@ body {
 
 .discover-rail-card {
   transform:
-    translate3d(0, calc(var(--discover-rail-emphasis) * -12px), 0)
-    scale(calc(1 + (var(--discover-rail-emphasis) * 0.052)));
+    translate3d(0, calc(var(--discover-rail-visual-emphasis) * -12px), 0)
+    scale(calc(1 + (var(--discover-rail-visual-emphasis) * 0.052)));
   transform-origin: left top;
   will-change: transform, box-shadow, border-color, background;
   backface-visibility: hidden;
@@ -329,6 +368,22 @@ body {
     background 360ms ease,
     border-color 320ms ease,
     box-shadow 360ms ease;
+}
+
+.discover-horizontal-rail[data-scroll-state="active"] .discover-rail-card {
+  transition:
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1),
+    background 240ms ease,
+    border-color 220ms ease,
+    box-shadow 240ms ease;
+}
+
+.discover-horizontal-rail[data-scroll-state="settling"] .discover-rail-card {
+  transition:
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    background 280ms ease,
+    border-color 260ms ease,
+    box-shadow 280ms ease;
 }
 
 .discover-rail-item > .discover-rail-card {
@@ -459,9 +514,8 @@ body {
   inset: 0;
   border-radius: inherit;
   background:
-    radial-gradient(circle at 18% 18%, var(--player-tint), transparent 34%),
-    radial-gradient(circle at top center, var(--accent-glow), transparent 36%),
-    radial-gradient(circle at 82% 88%, var(--accent-soft), transparent 28%),
+    radial-gradient(circle at 16% 18%, var(--player-tint), transparent 30%),
+    radial-gradient(circle at 82% 86%, var(--accent-soft), transparent 24%),
     linear-gradient(180deg, transparent 0%, rgba(255, 255, 255, 0.02) 100%);
   pointer-events: none;
   transition: background 380ms ease;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -147,6 +147,7 @@ export interface DiscoverSection {
   id: string;
   title: string;
   subtitle?: string;
+  origin?: "personal" | "market";
   items: DiscoverItem[];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-music-bot",
-  "version": "0.7.10",
+  "version": "0.8.0",
   "description": "YouTube Music 點歌機器人 WebUI",
   "type": "module",
   "scripts": {

--- a/src/__tests__/api.health.test.ts
+++ b/src/__tests__/api.health.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import api from "../routes/api.ts";
+import { getAppMetadata } from "../utils/app-metadata.ts";
+
+describe("/api/health", () => {
+  test("returns ok status with version metadata", async () => {
+    const response = await api.request("/health");
+
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+      success: boolean;
+      data: {
+        status: string;
+        version: string;
+        gitSha: string;
+        uptimeSeconds: number;
+      };
+    };
+
+    expect(payload.success).toBe(true);
+    expect(payload.data.status).toBe("ok");
+    expect(payload.data.version).toBe(getAppMetadata().appVersion);
+    expect(typeof payload.data.uptimeSeconds).toBe("number");
+    expect(payload.data.uptimeSeconds).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/__tests__/discover.service.test.ts
+++ b/src/__tests__/discover.service.test.ts
@@ -7,6 +7,7 @@ import {
   DISCOVER_MARKETS,
   DiscoverService,
 } from "../services/discover.service.ts";
+import { getMusicService } from "../services/music.service.ts";
 import type {
   DiscoverCollectionItem,
   DiscoverMarketCode,
@@ -14,6 +15,34 @@ import type {
   DiscoverTrackItem,
   Track,
 } from "../types/index.ts";
+
+type RestorableMethod = {
+  target: Record<string, unknown>;
+  key: string;
+  original: unknown;
+};
+
+const restores: RestorableMethod[] = [];
+
+function stubMethod<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  replacement: T[K],
+): void {
+  restores.push({
+    target: target as Record<string, unknown>,
+    key: key as string,
+    original: target[key],
+  });
+  target[key] = replacement;
+}
+
+function restoreMethods(): void {
+  while (restores.length > 0) {
+    const restore = restores.pop()!;
+    restore.target[restore.key] = restore.original;
+  }
+}
 
 function createTrack(videoId: string, title: string): Track {
   return {
@@ -100,6 +129,7 @@ describe("DiscoverService", () => {
   });
 
   afterEach(() => {
+    restoreMethods();
     service.close();
     rmSync(tempDir, { recursive: true, force: true });
   });
@@ -304,6 +334,68 @@ describe("DiscoverService", () => {
     expect(response.fetchedAt).toBe("2026-03-27T00:05:00.000Z");
   });
 
+  test("prepends personalized sections to the base feed and skips them for mood feeds", async () => {
+    service.recordTrackRequests([
+      createTrack("seed-1", "Seed 1"),
+      createTrack("seed-2", "Seed 2"),
+      createTrack("seed-3", "Seed 3"),
+    ]);
+
+    const musicService = getMusicService();
+    stubMethod(musicService, "getMixTracks", (async () => []) as
+      typeof musicService.getMixTracks);
+
+    const baseSection = createSection(
+      "base-section",
+      "熱門內容",
+      createTrackItem("track-1", "Track One"),
+    );
+    const moodSection = createSection(
+      "mood-section",
+      "今晚派對",
+      createCollectionItem("VLparty", "Party Mix"),
+    );
+
+    (service as unknown as { getBaseFeed: () => Promise<unknown> }).getBaseFeed =
+      async () => ({
+        market: "TW",
+        moods: [
+          {
+            key: "mood-1",
+            label: "派對",
+            endpoint: {
+              browseId: "FEmusic_mood_party",
+            },
+          },
+        ],
+        sections: [baseSection],
+        warnings: [],
+        fetchedAt: "2026-03-27T00:00:00.000Z",
+      });
+    (
+      service as unknown as {
+        getMoodFeed: (
+          market: DiscoverMarketCode,
+          mood: { key: string; label: string },
+        ) => Promise<unknown>;
+      }
+    ).getMoodFeed = async () => ({
+      sections: [moodSection],
+      warnings: [],
+      fetchedAt: "2026-03-27T00:05:00.000Z",
+    });
+
+    const baseResponse = await service.getFeed("TW");
+
+    expect(baseResponse.sections[0]?.id).toBe("personal-recent");
+    expect(baseResponse.sections[0]?.origin).toBe("personal");
+    expect(baseResponse.sections.at(-1)).toEqual(baseSection);
+
+    const moodResponse = await service.getFeed("TW", "mood-1");
+
+    expect(moodResponse.sections).toEqual([moodSection]);
+  });
+
   test("hydrates missing metadata for discover video items", async () => {
     const section = createSection(
       "video-section",
@@ -362,5 +454,118 @@ describe("DiscoverService", () => {
         thumbnail: "https://img.youtube.com/vi/video-1/mqdefault.jpg",
       },
     });
+  });
+
+  test("getRecentlyRequested orders by recency within the window", async () => {
+    service.recordTrackRequests([
+      createTrack("track-old", "Old Track"),
+      createTrack("track-new", "New Track"),
+    ]);
+
+    const statsStore = (
+      service as unknown as {
+        statsStore: {
+          getRecentlyRequested: (
+            limit?: number,
+            sinceDays?: number,
+          ) => Array<{ track: Track; lastRequestedAt: string }>;
+          db: {
+            query: (sql: string) => {
+              run: (...args: unknown[]) => void;
+            };
+          };
+        };
+      }
+    ).statsStore;
+
+    // 把 track-old 的點播時間推到視窗之外
+    statsStore.db
+      .query(
+        "UPDATE discover_track_activity SET last_requested_at = ?1 WHERE video_id = ?2",
+      )
+      .run(new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(), "track-old");
+
+    const entries = statsStore.getRecentlyRequested(10, 30);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.track.videoId).toBe("track-new");
+  });
+
+  test("builds personalized sections from local stats with mix recommendations", async () => {
+    const requestedTracks = ["seed-1", "seed-2", "seed-3", "seed-4"].map(
+      (id, index) => createTrack(id, `Seed ${index + 1}`),
+    );
+    service.recordTrackRequests(requestedTracks);
+
+    const musicService = getMusicService();
+    const mixCalls: string[] = [];
+    stubMethod(musicService, "getMixTracks", (async (
+      videoId: string,
+      _limit?: number,
+    ) => {
+      mixCalls.push(videoId);
+      return [
+        createTrack(`mix-${videoId}-a`, `Mix of ${videoId} A`),
+        createTrack(`mix-${videoId}-b`, `Mix of ${videoId} B`),
+        createTrack("seed-1", "Seed 1"),
+      ];
+    }) as typeof musicService.getMixTracks);
+
+    const sections = await (
+      service as unknown as {
+        getPersonalizedSections: () => Promise<DiscoverSection[]>;
+      }
+    ).getPersonalizedSections();
+
+    expect(sections.map((section) => section.id)).toEqual([
+      "personal-recent",
+      "personal-for-you",
+    ]);
+    expect(sections[0]?.origin).toBe("personal");
+    expect(sections[0]?.items.length).toBeGreaterThanOrEqual(3);
+
+    const recommended = sections[1]!;
+    expect(recommended.origin).toBe("personal");
+    const recommendedIds = recommended.items.map((item) => item.id);
+    // 種子與最近常聽的歌曲不應重複出現在推薦清單
+    expect(recommendedIds).not.toContain("seed-1");
+    expect(recommendedIds.length).toBeGreaterThanOrEqual(3);
+    expect(mixCalls.length).toBeGreaterThan(0);
+  });
+
+  test("returns no personalized sections when stats are empty", async () => {
+    const musicService = getMusicService();
+    stubMethod(musicService, "getMixTracks", (async () => {
+      throw new Error("should not be called");
+    }) as typeof musicService.getMixTracks);
+
+    const sections = await (
+      service as unknown as {
+        getPersonalizedSections: () => Promise<DiscoverSection[]>;
+      }
+    ).getPersonalizedSections();
+
+    expect(sections).toEqual([]);
+  });
+
+  test("degrades gracefully when mix recommendations fail", async () => {
+    service.recordTrackRequests([
+      createTrack("seed-1", "Seed 1"),
+      createTrack("seed-2", "Seed 2"),
+      createTrack("seed-3", "Seed 3"),
+    ]);
+
+    const musicService = getMusicService();
+    // getMixTracks 在實作中對錯誤回傳空陣列;這裡模擬全部種子皆無結果
+    stubMethod(musicService, "getMixTracks", (async () => []) as
+      typeof musicService.getMixTracks);
+
+    const sections = await (
+      service as unknown as {
+        getPersonalizedSections: () => Promise<DiscoverSection[]>;
+      }
+    ).getPersonalizedSections();
+
+    expect(sections.map((section) => section.id)).toEqual(["personal-recent"]);
   });
 });

--- a/src/__tests__/mix.queue.service.test.ts
+++ b/src/__tests__/mix.queue.service.test.ts
@@ -88,7 +88,6 @@ function suppressNextTrackPreload(
 function stubTrackLoudness(
   musicService: ReturnType<typeof getMusicService>,
 ): void {
-  stubMethod(musicService, "getTrackLoudness", async () => null);
 }
 
 describe("QueueService mix creation", () => {

--- a/src/__tests__/player.service.test.ts
+++ b/src/__tests__/player.service.test.ts
@@ -356,6 +356,92 @@ describe("PlayerService - seek functionality", () => {
       expect(args).not.toContain("--softvol-max=200");
     });
 
+    test("should include the dynaudnorm audio filter by default", () => {
+      const fakeProcess = {} as ChildProcess;
+      const session = createSession(fakeProcess);
+      const player = playerService as unknown as {
+        buildMpvArgs: (
+          session: ReturnType<typeof createSession>,
+          options: { volume: number; startPaused: boolean },
+        ) => string[];
+      };
+
+      const args = player.buildMpvArgs(session, {
+        volume: 70,
+        startPaused: false,
+      });
+
+      const filterArg = args.find((arg) => arg.startsWith("--af="));
+      expect(filterArg).toBeDefined();
+      expect(filterArg).toContain("dynaudnorm");
+    });
+
+    test("should omit the audio filter when volume normalization is disabled", () => {
+      const fakeProcess = {} as ChildProcess;
+      const session = createSession(fakeProcess);
+      const player = playerService as unknown as {
+        buildMpvArgs: (
+          session: ReturnType<typeof createSession>,
+          options: { volume: number; startPaused: boolean },
+        ) => string[];
+      };
+
+      playerService.setVolumeNormalizationEnabled(false);
+
+      const args = player.buildMpvArgs(session, {
+        volume: 70,
+        startPaused: false,
+      });
+
+      expect(args.some((arg) => arg.startsWith("--af="))).toBe(false);
+    });
+
+    test("should toggle the audio filter on live sessions through IPC", () => {
+      const fakeProcess = {} as ChildProcess;
+      const activeSession = createSession(fakeProcess);
+      const standbySession = createSession(fakeProcess);
+      const ipcSpy = mock(
+        (_session: ReturnType<typeof createSession>, _command: unknown[]) =>
+          true,
+      );
+      const player = playerService as unknown as {
+        activeSession: ReturnType<typeof createSession> | null;
+        standbySession: ReturnType<typeof createSession> | null;
+        sendIpcCommand: (
+          session: ReturnType<typeof createSession>,
+          command: unknown[],
+        ) => boolean;
+      };
+
+      stubMethod(
+        player,
+        "sendIpcCommand",
+        ipcSpy as unknown as typeof player.sendIpcCommand,
+      );
+      player.activeSession = activeSession;
+      player.standbySession = standbySession;
+
+      playerService.setVolumeNormalizationEnabled(false);
+
+      expect(ipcSpy).toHaveBeenCalledTimes(2);
+      expect(ipcSpy.mock.calls[0]?.[1]).toEqual(["af", "clr", ""]);
+
+      playerService.setVolumeNormalizationEnabled(true);
+
+      expect(ipcSpy).toHaveBeenCalledTimes(4);
+      const enableCommand = ipcSpy.mock.calls[2]?.[1] as string[];
+      expect(enableCommand[0]).toBe("af");
+      expect(enableCommand[1]).toBe("set");
+      expect(enableCommand[2]).toContain("dynaudnorm");
+
+      // 相同狀態重複設定不應再送 IPC
+      playerService.setVolumeNormalizationEnabled(true);
+      expect(ipcSpy).toHaveBeenCalledTimes(4);
+
+      player.activeSession = null;
+      player.standbySession = null;
+    });
+
     test("should wait for a positive time-pos before confirming playback", () => {
       const fakeProcess = {
         kill: mock(() => true),

--- a/src/__tests__/queue.autoplay.test.ts
+++ b/src/__tests__/queue.autoplay.test.ts
@@ -71,7 +71,6 @@ function suppressNextTrackPreload(
 function stubTrackLoudness(
   musicService: ReturnType<typeof getMusicService>,
 ): void {
-  stubMethod(musicService, "getTrackLoudness", async () => null);
 }
 
 const searchedTrack: Track = {

--- a/src/__tests__/queue.service.test.ts
+++ b/src/__tests__/queue.service.test.ts
@@ -282,22 +282,18 @@ describe("QueueService - seekTo functionality", () => {
       expect(queueService.getState().playbackSettings).toEqual(nextSettings);
     });
 
-    test("should resync the current and next track when volume normalization changes", () => {
-      const currentTrack = track("current-track", "Current Track");
-      const nextTrack = track("next-track", "Next Track");
-      const syncTrackSpy = mock(async (_track: Track | null) => {});
+    test("should toggle the player volume normalization filter when the setting changes", () => {
+      const playerService = getPlayerService();
+      const toggleSpy = mock((_enabled: boolean) => {});
       const syncPreloadSpy = mock(async (_options?: { force?: boolean }) => false);
       const internalQueueService = queueService as unknown as {
-        currentTrack: Track | null;
-        queue: Track[];
-        syncTrackVolumeNormalization: (track: Track | null) => Promise<void>;
         syncNextTrackPreload: (options?: { force?: boolean }) => Promise<boolean>;
       };
 
       stubMethod(
-        internalQueueService,
-        "syncTrackVolumeNormalization",
-        syncTrackSpy as unknown as typeof internalQueueService.syncTrackVolumeNormalization,
+        playerService,
+        "setVolumeNormalizationEnabled",
+        toggleSpy as unknown as typeof playerService.setVolumeNormalizationEnabled,
       );
       stubMethod(
         internalQueueService,
@@ -305,288 +301,19 @@ describe("QueueService - seekTo functionality", () => {
         syncPreloadSpy as unknown as typeof internalQueueService.syncNextTrackPreload,
       );
 
-      internalQueueService.currentTrack = currentTrack;
-      internalQueueService.queue = [nextTrack];
+      queueService.setPlaybackSettings({
+        volumeNormalizationEnabled: false,
+      });
+
+      expect(toggleSpy).toHaveBeenCalledTimes(1);
+      expect(toggleSpy.mock.calls[0]?.[0]).toBe(false);
+      expect(syncPreloadSpy).toHaveBeenCalledWith({ force: true });
 
       queueService.setPlaybackSettings({
         volumeNormalizationEnabled: false,
       });
 
-      expect(syncTrackSpy).toHaveBeenCalledTimes(2);
-      expect(syncTrackSpy.mock.calls[0]?.[0]).toBe(currentTrack);
-      expect(syncTrackSpy.mock.calls[1]?.[0]).toBe(nextTrack);
-      expect(syncPreloadSpy).toHaveBeenCalledWith({ force: true });
-    });
-
-    test("should prefer loudnessDb metadata without boosting quieter tracks", async () => {
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => ({
-          loudnessDb: -4.2800007,
-          perceptualLoudnessDb: -18.28,
-        })) as typeof musicService.getTrackLoudness,
-      );
-
-      const volumeMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-perceptual", "Perceptual Track"),
-        );
-
-      expect(volumeMultiplier).toBe(1);
-    });
-
-    test("should prefer loudnessDb over perceptual metadata and never boost", async () => {
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => ({
-          loudnessDb: -4.2800007,
-          perceptualLoudnessDb: -7.39,
-        })) as typeof musicService.getTrackLoudness,
-      );
-
-      const volumeMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-conflicting-quiet", "Conflicting Quiet Track"),
-        );
-
-      expect(volumeMultiplier).toBe(1);
-    });
-
-    test("should attenuate loud tracks based on loudnessDb", async () => {
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => ({
-          loudnessDb: 6.61,
-          perceptualLoudnessDb: -7.39,
-        })) as typeof musicService.getTrackLoudness,
-      );
-
-      const volumeMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-perceptual-loud", "Perceptual Loud Track"),
-        );
-
-      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, -6.61 / 20), 5);
-      expect(volumeMultiplier).toBeLessThan(1);
-    });
-
-    test("should use a conservative loudnessDb fallback without boosting quieter tracks", async () => {
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => ({
-          loudnessDb: -4.2800007,
-        })) as typeof musicService.getTrackLoudness,
-      );
-
-      const volumeMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-fallback-quiet", "Fallback Quiet Track"),
-        );
-
-      expect(volumeMultiplier).toBe(1);
-    });
-
-    test("should fall back to perceptual metadata when loudnessDb is unavailable", async () => {
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => ({
-          perceptualLoudnessDb: -10,
-        })) as typeof musicService.getTrackLoudness,
-      );
-
-      const volumeMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-perceptual-fallback", "Perceptual Fallback Track"),
-        );
-
-      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, -4 / 20), 5);
-      expect(volumeMultiplier).toBeLessThan(1);
-    });
-
-    test("should keep neutral volume for zero loudnessDb and missing metadata", async () => {
-      const loudnessSamples = [
-        { loudnessDb: 0 },
-        {},
-        null,
-      ];
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-      let callIndex = 0;
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => loudnessSamples[callIndex++] ?? null) as typeof musicService.getTrackLoudness,
-      );
-
-      await expect(
-        internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-zero-loudness", "Zero Loudness Track"),
-        ),
-      ).resolves.toBe(1);
-      await expect(
-        internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-empty-metadata", "Empty Metadata Track"),
-        ),
-      ).resolves.toBe(1);
-      await expect(
-        internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-null-metadata", "Null Metadata Track"),
-        ),
-      ).resolves.toBe(1);
-    });
-
-    test("should ignore non-finite loudness metadata", async () => {
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => ({
-          loudnessDb: Number.NaN,
-          perceptualLoudnessDb: Number.POSITIVE_INFINITY,
-        })) as typeof musicService.getTrackLoudness,
-      );
-
-      const volumeMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-invalid-metadata", "Invalid Metadata Track"),
-        );
-
-      expect(volumeMultiplier).toBe(1);
-    });
-
-    test("should attenuate loud tracks when only loudnessDb fallback is available", async () => {
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => ({
-          loudnessDb: 6.21,
-        })) as typeof musicService.getTrackLoudness,
-      );
-
-      const volumeMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-fallback-loud", "Fallback Loud Track"),
-        );
-
-      expect(volumeMultiplier).toBeCloseTo(Math.pow(10, -6.21 / 20), 5);
-      expect(volumeMultiplier).toBeLessThan(1);
-    });
-
-    test("should clamp normalization gain to attenuation-only boundaries", async () => {
-      const loudnessSamples = [
-        { perceptualLoudnessDb: -30 },
-        { loudnessDb: 20 },
-      ];
-      const musicService = getMusicService() as unknown as {
-        getTrackLoudness: (videoId: string) => Promise<{
-          loudnessDb?: number;
-          perceptualLoudnessDb?: number;
-        } | null>;
-      };
-      const internalQueueService = queueService as unknown as {
-        resolveTrackVolumeMultiplier: (track: Track | null) => Promise<number>;
-      };
-      let callIndex = 0;
-
-      stubMethod(
-        musicService,
-        "getTrackLoudness",
-        (async () => loudnessSamples[callIndex++] ?? null) as typeof musicService.getTrackLoudness,
-      );
-
-      const quietTrackMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-quiet", "Quiet Track"),
-        );
-      const attenuatedMultiplier =
-        await internalQueueService.resolveTrackVolumeMultiplier(
-          track("track-attenuate", "Attenuated Track"),
-        );
-
-      expect(quietTrackMultiplier).toBe(1);
-      expect(attenuatedMultiplier).toBeCloseTo(Math.pow(10, -12 / 20), 5);
+      expect(toggleSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/__tests__/release-notes.service.test.ts
+++ b/src/__tests__/release-notes.service.test.ts
@@ -91,7 +91,7 @@ describe("ReleaseNotesService", () => {
     expect(response.source).toBe("fallback");
     expect(response.currentRelease?.version).toBe("0.7.0");
     expect(response.releases.map((entry) => entry.version)).toContain("0.7.0");
-    expect(response.releases[0]?.version).toBe("0.7.10");
+    expect(response.releases[0]?.version).toBe("0.8.0");
     expect(
       response.warnings.some((warning) => warning.includes("已改用本機版本說明")),
     ).toBe(true);

--- a/src/data/release-notes.ts
+++ b/src/data/release-notes.ts
@@ -1,6 +1,76 @@
 import type { ReleaseNotesEntry } from "../types/index.ts";
 
 const fallbackReleaseNotesByVersion: Record<string, ReleaseNotesEntry> = {
+  "0.8.0": {
+    version: "0.8.0",
+    title: "動態音量平衡與 Discover 個人化",
+    publishedAt: "2026-06-12",
+    status: "preview",
+    summary:
+      "音量平衡改用播放器端動態響度濾鏡,新增 UI 開關;Discover 加入由本站點播紀錄驅動的個人化區塊,並補上多項安全與部署強化。",
+    sections: [
+      {
+        category: "changed",
+        title: "音量平衡重構",
+        description: "從每首歌固定增益改為播放時動態響度正規化。",
+        items: [
+          "播放管線改用 mpv 的 dynaudnorm 濾鏡即時平衡響度,歌曲內部與歌曲之間的音量起伏都會被拉向一致聽感。",
+          "桌面播放器與手機 Now Playing 介面新增「音量平衡」開關,切換後立即生效、不需重新播放。",
+          "移除舊的 YouTube loudness metadata 靜態增益路徑,避免與動態濾鏡疊加造成過度衰減。",
+        ],
+      },
+      {
+        category: "added",
+        title: "Discover 個人化",
+        description: "讓 Discover 從通用排行榜變成跟著這個站的口味走。",
+        items: [
+          "新增「最近常聽」區塊,呈現近 30 天的本站點播紀錄。",
+          "新增「為你推薦」區塊,以最常點播的歌曲為種子延伸相似曲目。",
+          "尚無點播紀錄時隱藏空白的本站熱門點播卡片,冷啟動直接顯示市場內容。",
+        ],
+      },
+      {
+        category: "fixed",
+        title: "安全與部署強化",
+        description: "收斂預設安全姿態並補齊生產環境基礎設施。",
+        items: [
+          "CORS 改為可透過 CORS_ORIGIN 白名單設定,未設定時不再同時允許萬用來源與憑證。",
+          "Docker 映像建置時驗證 yt-dlp 下載檔的 SHA-256 checksum。",
+          "新增 /api/health 健康檢查端點與 docker-compose healthcheck,並補上 .env.example 與啟動環境檢查。",
+          "修正 Ctrl+C / docker stop 時伺服器不會確實退出的問題。",
+        ],
+      },
+    ],
+  },
+  "0.7.11": {
+    version: "0.7.11",
+    title: "播放器介面全面重整",
+    publishedAt: "2026-05-09",
+    status: "preview",
+    summary:
+      "重新整理 WebUI 的視覺系統、手機安全區域與搜尋空狀態，保留專輯封面取色背景，同時降低主要流程被介面裝飾或彈窗打斷的情況。",
+    sections: [
+      {
+        category: "changed",
+        title: "視覺系統重整",
+        description: "把播放器 UI 收斂到更穩定的 design token 與元件語言。",
+        items: [
+          "建立更一致的 surface、文字、陰影、圓角與安全區域 token，讓桌面與手機版能共用同一套視覺節奏。",
+          "保留專輯封面取色與動態背景，但降低過多光暈與膠囊裝飾，讓歌曲資訊和播放控制更清楚。",
+        ],
+      },
+      {
+        category: "fixed",
+        title: "手機與搜尋體驗修正",
+        description: "修正實機檢視時會直接影響閱讀與操作的 UI 問題。",
+        items: [
+          "手機內容區改為避開底部迷你播放器與 TabBar，避免 Discover 卡片或列表內容被固定列遮住。",
+          "搜尋與空狀態改用動態主題 token，改善淺色背景上文字對比不足的問題。",
+          "版本更新視窗不再首次進入就自動覆蓋主畫面，改由版本徽章提示並讓使用者自行開啟。",
+        ],
+      },
+    ],
+  },
   "0.7.10": {
     version: "0.7.10",
     title: "Dynamic Voice 保守音量平衡",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,22 @@
 import { createServer } from './server.ts';
 import { getAppMetadata } from "./utils/app-metadata.ts";
+import { validateEnvironment } from "./utils/env.ts";
 import { logRuntimeDependencyStatus } from "./utils/runtime-dependencies.ts";
 
 const metadata = getAppMetadata();
+validateEnvironment();
 logRuntimeDependencyStatus();
 const server = createServer();
 const displayHost = process.env.HOST?.trim() || "localhost";
+
+// player.service 的 SIGINT/SIGTERM handler 只負責清理 mpv,不會結束 process;
+// 這裡停止接受新連線後明確退出,避免 Ctrl+C / docker stop 時卡住。
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    server.stop();
+    process.exit(0);
+  });
+}
 
 console.log(`
 ╔════════════════════════════════════════════╗

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -861,6 +861,23 @@ api.delete("/queue/:index", (c) => {
 });
 
 /**
+ * GET /api/health
+ * 健康檢查端點,供 docker-compose healthcheck 與監控使用
+ */
+api.get("/health", (c) => {
+  const metadata = getAppMetadata();
+  return c.json<ApiResponse>({
+    success: true,
+    data: {
+      status: "ok",
+      version: metadata.appVersion,
+      gitSha: metadata.gitSha,
+      uptimeSeconds: Math.round(process.uptime()),
+    },
+  });
+});
+
+/**
  * GET /api/system/info
  * 取得系統版本資訊
  */

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,15 +20,40 @@ type SocketData = {
 
 const app = new Hono();
 
+// CORS_ORIGIN:逗號分隔的允許來源白名單(例如 "https://music.example.com,http://192.168.1.10:3000")。
+// 未設定時退回開放 origin,但不可與 credentials 並用(W3C 規範禁止 "*" + credentials 組合)。
+function resolveCorsOrigins(): string[] | null {
+  const raw = process.env.CORS_ORIGIN?.trim();
+  if (!raw) {
+    return null;
+  }
+
+  const origins = raw
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  return origins.length > 0 ? origins : null;
+}
+
+const corsOrigins = resolveCorsOrigins();
+
 // 添加 CORS 支持（必須放在 serveStatic 之前）
 app.use(
   "/*",
-  cors({
-    origin: "*",
-    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization"],
-    credentials: true,
-  }),
+  cors(
+    corsOrigins
+      ? {
+          origin: corsOrigins,
+          allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+          allowHeaders: ["Content-Type", "Authorization"],
+          credentials: true,
+        }
+      : {
+          origin: "*",
+          allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+          allowHeaders: ["Content-Type", "Authorization"],
+        },
+  ),
 );
 
 // 提供靜態檔案

--- a/src/services/discover.service.ts
+++ b/src/services/discover.service.ts
@@ -17,11 +17,18 @@ import type {
   TopRequestedEntry,
   Track,
 } from "../types/index.ts";
+import { getMusicService } from "./music.service.ts";
 import { log } from "../utils/logger.ts";
 
 const DISCOVER_FEED_CACHE_TTL_MS = 15 * 60 * 1000;
 const DISCOVER_VIDEO_METADATA_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 const DEFAULT_TOP_REQUESTED_LIMIT = 10;
+const DEFAULT_RECENTLY_REQUESTED_LIMIT = 10;
+const RECENTLY_REQUESTED_WINDOW_DAYS = 30;
+const PERSONALIZED_SEED_COUNT = 3;
+const PERSONALIZED_MIX_TRACKS_PER_SEED = 8;
+const PERSONALIZED_SECTION_MAX_ITEMS = 20;
+const PERSONALIZED_SECTION_MIN_ITEMS = 3;
 const MOODS_AND_GENRES_BROWSE_ID = "FEmusic_moods_and_genres";
 
 type DiscoverMarketConfig = DiscoverMarket & {
@@ -1101,6 +1108,48 @@ class DiscoverStatsStore {
     }));
   }
 
+  getRecentlyRequested(
+    limit: number = DEFAULT_RECENTLY_REQUESTED_LIMIT,
+    sinceDays: number = RECENTLY_REQUESTED_WINDOW_DAYS,
+  ): TopRequestedEntry[] {
+    const since = new Date(
+      Date.now() - sinceDays * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    const rows = this.db
+      .query(`
+        SELECT
+          activity.video_id,
+          activity.request_count,
+          activity.last_requested_at,
+          catalog.title,
+          catalog.artist,
+          catalog.thumbnail,
+          catalog.duration,
+          catalog.updated_at
+        FROM discover_track_activity AS activity
+        LEFT JOIN discover_track_catalog AS catalog
+          ON catalog.video_id = activity.video_id
+        WHERE activity.last_requested_at >= ?1
+        ORDER BY activity.last_requested_at DESC, activity.request_count DESC
+        LIMIT ?2
+      `)
+      .all(since, limit) as JoinedTopRequestedRow[];
+
+    return rows.map((row, index) => ({
+      rank: index + 1,
+      requestCount: row.request_count,
+      lastRequestedAt: row.last_requested_at,
+      track: {
+        videoId: row.video_id,
+        title: row.title || "Unknown",
+        artist: row.artist || "Unknown",
+        duration: row.duration || 0,
+        thumbnail: row.thumbnail || undefined,
+      },
+    }));
+  }
+
   close(): void {
     this.db.close();
   }
@@ -1127,6 +1176,11 @@ export class DiscoverService {
     string,
     Promise<DiscoverVideoMetadata | null>
   >();
+  private recommendationCache: {
+    seedKey: string;
+    items: DiscoverItem[];
+    expiresAt: number;
+  } | null = null;
 
   constructor(databasePath: string = getDefaultDiscoverStatsDbPath()) {
     this.statsStore = new DiscoverStatsStore(databasePath);
@@ -1233,6 +1287,119 @@ export class DiscoverService {
     });
   }
 
+  // 依本站點播統計產生個人化區塊;統計為空時回傳空陣列,讓畫面自然退回市場內容。
+  private async getPersonalizedSections(): Promise<DiscoverSection[]> {
+    const sections: DiscoverSection[] = [];
+
+    try {
+      const recentEntries = await this.enrichTopRequestedMetadata(
+        this.statsStore.getRecentlyRequested(),
+      );
+
+      const recentItems = recentEntries.map((entry) =>
+        createDiscoverTrackItem(entry.track),
+      );
+
+      if (recentItems.length >= PERSONALIZED_SECTION_MIN_ITEMS) {
+        sections.push({
+          id: "personal-recent",
+          title: "最近常聽",
+          subtitle: "根據這裡最近的點播紀錄",
+          origin: "personal",
+          items: recentItems,
+        });
+      }
+
+      const recommendedItems = await this.getRecommendedItems(
+        new Set(recentItems.map((item) => item.id)),
+      );
+
+      if (recommendedItems.length >= PERSONALIZED_SECTION_MIN_ITEMS) {
+        sections.push({
+          id: "personal-for-you",
+          title: "為你推薦",
+          subtitle: "從你最常點播的歌曲延伸",
+          origin: "personal",
+          items: recommendedItems,
+        });
+      }
+    } catch (error) {
+      log.warn("Failed to build personalized discover sections", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    return sections;
+  }
+
+  private async getRecommendedItems(
+    excludedIds: Set<string>,
+  ): Promise<DiscoverItem[]> {
+    const seeds = this.statsStore.getTopRequested(PERSONALIZED_SEED_COUNT);
+    if (seeds.length === 0) {
+      return [];
+    }
+
+    const seedKey = seeds.map((seed) => seed.track.videoId).join(",");
+    const now = Date.now();
+
+    if (
+      this.recommendationCache &&
+      this.recommendationCache.seedKey === seedKey &&
+      this.recommendationCache.expiresAt > now
+    ) {
+      return this.recommendationCache.items.filter(
+        (item) => !excludedIds.has(item.id),
+      );
+    }
+
+    const seedVideoIds = new Set(seeds.map((seed) => seed.track.videoId));
+    const musicService = getMusicService();
+    // getMixTracks 失敗時回傳空陣列,單一種子失敗只會讓推薦變少,不會整段失敗。
+    const mixResults = await Promise.all(
+      seeds.map((seed) =>
+        musicService.getMixTracks(
+          seed.track.videoId,
+          PERSONALIZED_MIX_TRACKS_PER_SEED,
+        ),
+      ),
+    );
+
+    const seenIds = new Set<string>();
+    const items: DiscoverItem[] = [];
+
+    for (const tracks of mixResults) {
+      for (const track of tracks) {
+        if (
+          !track.videoId ||
+          seedVideoIds.has(track.videoId) ||
+          seenIds.has(track.videoId)
+        ) {
+          continue;
+        }
+
+        seenIds.add(track.videoId);
+        items.push(createDiscoverTrackItem(track));
+
+        if (items.length >= PERSONALIZED_SECTION_MAX_ITEMS) {
+          break;
+        }
+      }
+
+      if (items.length >= PERSONALIZED_SECTION_MAX_ITEMS) {
+        break;
+      }
+    }
+
+    this.recommendationCache = {
+      seedKey,
+      items,
+      expiresAt: now + DISCOVER_FEED_CACHE_TTL_MS,
+    };
+
+    return items.filter((item) => !excludedIds.has(item.id));
+  }
+
   async getFeed(
     marketInput: string | null | undefined,
     moodKey?: string | null,
@@ -1243,11 +1410,12 @@ export class DiscoverService {
     const normalizedMoodKey = moodKey?.trim() || null;
 
     if (!normalizedMoodKey) {
+      const personalizedSections = await this.getPersonalizedSections();
       return {
         market,
         moods: publicMoods,
         selectedMood: null,
-        sections: baseFeed.sections,
+        sections: [...personalizedSections, ...baseFeed.sections],
         warnings: [...baseFeed.warnings],
         fetchedAt: baseFeed.fetchedAt,
       };

--- a/src/services/music.service.ts
+++ b/src/services/music.service.ts
@@ -34,11 +34,6 @@ import {
   type ParsedYouTubeCollection,
 } from "../utils/youtube-url.ts";
 
-export interface TrackLoudnessInfo {
-  loudnessDb?: number;
-  perceptualLoudnessDb?: number;
-}
-
 // 確保緩存目錄存在
 const cacheDir = join(process.cwd(), ".cache", "youtubei");
 if (!existsSync(cacheDir)) {
@@ -143,13 +138,6 @@ type YtDlpMetadata = {
   playlist_count?: number | string;
 };
 
-type PlayerAudioConfig = {
-  loudness_db?: number;
-  perceptual_loudness_db?: number;
-  loudnessDb?: number;
-  perceptualLoudnessDb?: number;
-};
-
 type MusicEntityArtist = {
   name?: string;
   channel_id?: string;
@@ -184,44 +172,6 @@ function getMixTrackArtistName(item: MixPanelItem): string {
   }
 
   return "Unknown";
-}
-
-function getFiniteNumber(value: unknown): number | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return undefined;
-  }
-
-  return value;
-}
-
-function extractTrackLoudnessInfo(info: any): TrackLoudnessInfo | null {
-  const audioConfig: PlayerAudioConfig | undefined =
-    info?.player_config?.audio_config ||
-    info?.playerConfig?.audioConfig ||
-    info?.raw_player_response?.playerConfig?.audioConfig ||
-    info?.page?.player_config?.audio_config;
-
-  if (!audioConfig) {
-    return null;
-  }
-
-  const loudnessDb =
-    getFiniteNumber(audioConfig.loudness_db) ??
-    getFiniteNumber(audioConfig.loudnessDb);
-  const perceptualLoudnessDb =
-    getFiniteNumber(audioConfig.perceptual_loudness_db) ??
-    getFiniteNumber(audioConfig.perceptualLoudnessDb);
-
-  if (loudnessDb === undefined && perceptualLoudnessDb === undefined) {
-    return null;
-  }
-
-  return {
-    ...(loudnessDb !== undefined ? { loudnessDb } : {}),
-    ...(perceptualLoudnessDb !== undefined
-      ? { perceptualLoudnessDb }
-      : {}),
-  };
 }
 
 export function normalizeMixTracks(
@@ -1046,11 +996,6 @@ export class YtDlpCommandError extends Error {
 class MusicService {
   private searchCache = new Map<string, SearchResult[]>();
   private lyricsCache = new Map<string, LyricLine[]>();
-  private trackLoudnessCache = new Map<string, TrackLoudnessInfo | null>();
-  private trackLoudnessInFlight = new Map<
-    string,
-    Promise<TrackLoudnessInfo | null>
-  >();
   private streamUrlCache = new Map<
     string,
     { result: StreamUrlResult; expiresAt: number }
@@ -1194,51 +1139,6 @@ class MusicService {
         return null;
       }
     }
-  }
-
-  async getTrackLoudness(videoId: string): Promise<TrackLoudnessInfo | null> {
-    const normalizedVideoId = videoId.trim();
-    if (!normalizedVideoId) {
-      return null;
-    }
-
-    if (this.trackLoudnessCache.has(normalizedVideoId)) {
-      const cached = this.trackLoudnessCache.get(normalizedVideoId);
-      return cached ? { ...cached } : null;
-    }
-
-    const inFlight = this.trackLoudnessInFlight.get(normalizedVideoId);
-    if (inFlight) {
-      const result = await inFlight;
-      return result ? { ...result } : null;
-    }
-
-    const request = (async () => {
-      try {
-        const yt = await getClient();
-        const info = await yt.getBasicInfo(normalizedVideoId);
-        const loudnessInfo = extractTrackLoudnessInfo(info);
-
-        this.trackLoudnessCache.set(
-          normalizedVideoId,
-          loudnessInfo ? { ...loudnessInfo } : null,
-        );
-
-        return loudnessInfo ? { ...loudnessInfo } : null;
-      } catch (error) {
-        log.warn("Failed to load track loudness metadata", {
-          error: error instanceof Error ? error.message : String(error),
-          videoId: normalizedVideoId,
-        });
-        return null;
-      } finally {
-        this.trackLoudnessInFlight.delete(normalizedVideoId);
-      }
-    })();
-
-    this.trackLoudnessInFlight.set(normalizedVideoId, request);
-    const result = await request;
-    return result ? { ...result } : null;
   }
 
   private async getCollectionSearchResult(

--- a/src/services/player.service.ts
+++ b/src/services/player.service.ts
@@ -47,6 +47,9 @@ const SESSION_VOLUME_RETRY_DELAY_MS = 120;
 const MAX_USER_VOLUME = 100;
 const MAX_SESSION_VOLUME = 200;
 const MAX_TRACK_VOLUME_MULTIPLIER = 1;
+// dynaudnorm:RMS 模式把感知響度拉向一致,3 秒級高斯平滑避免增益抽動(pumping),
+// m=5 限制最大增益避免把安靜前奏放大成噪音。
+const VOLUME_NORMALIZATION_FILTER = "dynaudnorm=f=400:g=15:m=5:r=0.8:p=0.9";
 
 class PlayerService {
   private static instance: PlayerService;
@@ -64,6 +67,7 @@ class PlayerService {
   private crossfadeTimer: ReturnType<typeof setInterval> | null = null;
   private crossfadeFinalizeTimeout: ReturnType<typeof setTimeout> | null = null;
   private retiringStopTimeouts = new Map<number, ReturnType<typeof setTimeout>>();
+  private volumeNormalizationEnabled = true;
 
   private constructor() {
     this.cleanupOrphanedMpvProcesses();
@@ -197,6 +201,9 @@ class PlayerService {
       "--network-timeout=60",
       "--gapless-audio=yes",
       ...(options.startPaused ? ["--pause=yes"] : []),
+      ...(this.volumeNormalizationEnabled
+        ? [`--af=lavfi=[${VOLUME_NORMALIZATION_FILTER}]`]
+        : []),
       ...this.getAudioArgs(),
     ];
 
@@ -1354,6 +1361,36 @@ class PlayerService {
     }
   }
 
+  setVolumeNormalizationEnabled(enabled: boolean): void {
+    if (this.volumeNormalizationEnabled === enabled) {
+      return;
+    }
+
+    this.volumeNormalizationEnabled = enabled;
+    log.info("Volume normalization filter toggled", { enabled });
+
+    const command = enabled
+      ? ["af", "set", `lavfi=[${VOLUME_NORMALIZATION_FILTER}]`]
+      : ["af", "clr", ""];
+
+    const applyToSession = (session: PlayerSession | null): void => {
+      if (!session) {
+        return;
+      }
+      this.sendIpcCommand(session, command);
+    };
+
+    applyToSession(this.activeSession);
+    applyToSession(this.standbySession);
+    for (const session of this.retiringSessions) {
+      applyToSession(session);
+    }
+  }
+
+  isVolumeNormalizationEnabled(): boolean {
+    return this.volumeNormalizationEnabled;
+  }
+
   seek(position: number): void {
     if (!this.isPlaying || !this.activeSession) {
       log.warn("Cannot seek: no active playback");
@@ -1395,6 +1432,7 @@ class PlayerService {
     this.clearCrossfadeTimer();
     this.clearCrossfadeFinalizeTimeout();
     this.clearAllRetiringStopTimeouts();
+    this.volumeNormalizationEnabled = true;
   }
 }
 

--- a/src/services/queue.service.ts
+++ b/src/services/queue.service.ts
@@ -6,10 +6,7 @@ import type {
   PlaybackSettings,
 } from "../types/index.ts";
 import { getPlayerService } from "./player.service.ts";
-import {
-  getMusicService,
-  type TrackLoudnessInfo,
-} from "./music.service.ts";
+import { getMusicService } from "./music.service.ts";
 import { pushRecentTrackId, selectRadioCandidates } from "./radio.helpers.ts";
 import { log } from "../utils/logger.ts";
 
@@ -38,10 +35,6 @@ const MAX_CROSSFADE_DURATION_SECONDS = 8;
 const MIN_CROSSFADE_START_POSITION_SECONDS = 5;
 const CROSSFADE_START_TOLERANCE_SECONDS = 0.35;
 const MAX_CROSSFADE_TRIGGER_LEAD_SECONDS = 1;
-const VOLUME_NORMALIZATION_REFERENCE_DB = -14;
-const MAX_VOLUME_NORMALIZATION_GAIN_DB = 0;
-const MAX_VOLUME_NORMALIZATION_ATTENUATION_DB = 12;
-const MAX_VOLUME_NORMALIZATION_MULTIPLIER = 1;
 
 class QueueService {
   private static instance: QueueService | undefined;
@@ -573,13 +566,10 @@ class QueueService {
     this.broadcastTrackLoading(nextTrack);
 
     try {
-      const volumeMultiplierPromise =
-        this.resolveTrackVolumeMultiplier(nextTrack);
       log.info("Fetching direct stream URL for playback", {
         videoId: nextTrack.videoId,
       });
       const streamResult = await getMusicService().getStreamUrl(nextTrack.videoId);
-      const volumeMultiplier = await volumeMultiplierPromise;
       log.info("Direct stream URL obtained", {
         source: streamResult.source,
         bitrate: streamResult.bitrate,
@@ -587,7 +577,6 @@ class QueueService {
       });
       await player.playUrl(streamResult.url, {
         trackId: nextTrack.videoId,
-        volumeMultiplier,
       });
       const didSyncDuration = this.syncCurrentDurationFromPlayer();
       log.info("Playback started successfully via direct stream URL", {
@@ -609,10 +598,7 @@ class QueueService {
       });
 
       try {
-        const volumeMultiplier = await this.resolveTrackVolumeMultiplier(nextTrack);
-        await player.play(nextTrack.videoId, {
-          volumeMultiplier,
-        });
+        await player.play(nextTrack.videoId);
         const didSyncDuration = this.syncCurrentDurationFromPlayer();
         log.info("Fallback playback started successfully via YouTube URL");
         if (didSyncDuration) {
@@ -725,13 +711,13 @@ class QueueService {
     const volumeNormalizationChanged =
       this.playbackSettings.volumeNormalizationEnabled !==
       nextSettings.volumeNormalizationEnabled;
-    const nextTrack = this.queue[0] ?? null;
     this.playbackSettings = nextSettings;
     this.broadcastState();
 
     if (volumeNormalizationChanged) {
-      void this.syncTrackVolumeNormalization(this.currentTrack);
-      void this.syncTrackVolumeNormalization(nextTrack);
+      getPlayerService().setVolumeNormalizationEnabled(
+        nextSettings.volumeNormalizationEnabled,
+      );
     }
 
     void this.syncNextTrackPreload({ force: true });
@@ -1037,15 +1023,12 @@ class QueueService {
 
     const request = (async () => {
       try {
-        const volumeMultiplierPromise =
-          this.resolveTrackVolumeMultiplier(nextTrack);
         log.info("Preloading next track", {
           videoId: nextTrack.videoId,
           title: nextTrack.title,
         });
 
         const streamResult = await getMusicService().getStreamUrl(nextTrack.videoId);
-        const volumeMultiplier = await volumeMultiplierPromise;
         if (
           requestId !== this.preloadRequestId ||
           this.queue[0]?.videoId !== nextTrack.videoId
@@ -1053,9 +1036,7 @@ class QueueService {
           return false;
         }
 
-        const ready = await player.preloadUrl(nextTrack.videoId, streamResult.url, {
-          volumeMultiplier,
-        });
+        const ready = await player.preloadUrl(nextTrack.videoId, streamResult.url);
         if (
           !ready ||
           requestId !== this.preloadRequestId ||
@@ -1197,39 +1178,6 @@ class QueueService {
     this.fetchAndBroadcastLyrics();
     this.maybeHydrateRadioQueue();
     void this.syncNextTrackPreload({ force: true });
-  }
-
-  private async syncTrackVolumeNormalization(track: Track | null): Promise<void> {
-    if (!track?.videoId) {
-      return;
-    }
-
-    const volumeMultiplier = await this.resolveTrackVolumeMultiplier(track);
-    getPlayerService().setTrackVolumeMultiplier(track.videoId, volumeMultiplier);
-  }
-
-  private async resolveTrackVolumeMultiplier(track: Track | null): Promise<number> {
-    if (!track?.videoId || !this.playbackSettings.volumeNormalizationEnabled) {
-      return 1;
-    }
-
-    const loudnessInfo = await getMusicService().getTrackLoudness(track.videoId);
-    const normalizationGainDb = resolveNormalizationGainDb(loudnessInfo);
-    const volumeMultiplier = clampVolumeNormalizationMultiplier(
-      Math.pow(10, normalizationGainDb / 20),
-    );
-    const metadataSource = resolveLoudnessMetadataSource(loudnessInfo);
-
-    log.debug("Resolved track volume normalization", {
-      videoId: track.videoId,
-      loudnessDb: loudnessInfo?.loudnessDb,
-      perceptualLoudnessDb: loudnessInfo?.perceptualLoudnessDb,
-      metadataSource,
-      normalizationGainDb,
-      volumeMultiplier,
-    });
-
-    return volumeMultiplier;
   }
 
   resetForTests(): void {
@@ -1514,63 +1462,6 @@ function arePlaybackSettingsEqual(
     left.crossfadeDurationSeconds === right.crossfadeDurationSeconds &&
     left.volumeNormalizationEnabled === right.volumeNormalizationEnabled
   );
-}
-
-function resolveNormalizationGainDb(
-  loudnessInfo: TrackLoudnessInfo | null,
-): number {
-  const loudnessDb = loudnessInfo?.loudnessDb;
-  if (typeof loudnessDb === "number" && Number.isFinite(loudnessDb)) {
-    return clampNormalizationGainDb(loudnessDb > 0 ? -loudnessDb : 0);
-  }
-
-  const perceptualLoudnessDb = loudnessInfo?.perceptualLoudnessDb;
-  if (
-    typeof perceptualLoudnessDb === "number" &&
-    Number.isFinite(perceptualLoudnessDb)
-  ) {
-    return clampNormalizationGainDb(
-      VOLUME_NORMALIZATION_REFERENCE_DB - perceptualLoudnessDb,
-    );
-  }
-
-  return 0;
-}
-
-// Volume normalization only attenuates louder tracks and never boosts quieter ones.
-function clampNormalizationGainDb(gainDb: number): number {
-  return Math.max(
-    -MAX_VOLUME_NORMALIZATION_ATTENUATION_DB,
-    Math.min(MAX_VOLUME_NORMALIZATION_GAIN_DB, gainDb),
-  );
-}
-
-function clampVolumeNormalizationMultiplier(multiplier: number): number {
-  if (!Number.isFinite(multiplier) || multiplier <= 0) {
-    return MAX_VOLUME_NORMALIZATION_MULTIPLIER;
-  }
-
-  return Math.min(MAX_VOLUME_NORMALIZATION_MULTIPLIER, multiplier);
-}
-
-function resolveLoudnessMetadataSource(
-  loudnessInfo: TrackLoudnessInfo | null,
-): "loudnessDb" | "perceptualLoudnessDb" | "none" {
-  if (
-    typeof loudnessInfo?.loudnessDb === "number" &&
-    Number.isFinite(loudnessInfo.loudnessDb)
-  ) {
-    return "loudnessDb";
-  }
-
-  if (
-    typeof loudnessInfo?.perceptualLoudnessDb === "number" &&
-    Number.isFinite(loudnessInfo.perceptualLoudnessDb)
-  ) {
-    return "perceptualLoudnessDb";
-  }
-
-  return "none";
 }
 
 function isValidRequester(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -147,6 +147,7 @@ export interface DiscoverSection {
   id: string;
   title: string;
   subtitle?: string;
+  origin?: "personal" | "market";
   items: DiscoverItem[];
 }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,41 @@
+import { existsSync } from "node:fs";
+import { log } from "./logger.ts";
+
+const KNOWN_LOG_LEVELS = ["DEBUG", "INFO", "WARN", "ERROR"];
+
+/**
+ * 啟動時檢查環境變數設定。
+ * 這個服務定位是 LAN 家用設備,設定有誤時以警告提示並沿用預設值,不中斷啟動。
+ */
+export function validateEnvironment(): void {
+  const port = process.env.PORT?.trim();
+  if (port && !Number.isFinite(Number.parseInt(port, 10))) {
+    log.warn("PORT is not a valid number; falling back to 3000", { port });
+  }
+
+  const ytdlpTimeout = process.env.YTDLP_TIMEOUT_MS?.trim();
+  if (ytdlpTimeout && !Number.isFinite(Number.parseInt(ytdlpTimeout, 10))) {
+    log.warn("YTDLP_TIMEOUT_MS is not a valid number; using default", {
+      ytdlpTimeoutMs: ytdlpTimeout,
+    });
+  }
+
+  const logLevel = process.env.LOG_LEVEL?.trim().toUpperCase();
+  if (logLevel && !KNOWN_LOG_LEVELS.includes(logLevel)) {
+    log.warn("Unknown LOG_LEVEL; using INFO", { logLevel });
+  }
+
+  const cookiesFile = process.env.YTDLP_COOKIES_FILE?.trim();
+  if (cookiesFile && !existsSync(cookiesFile)) {
+    log.warn("YTDLP_COOKIES_FILE is set but the file does not exist", {
+      cookiesFile,
+    });
+  }
+
+  const corsOrigin = process.env.CORS_ORIGIN?.trim();
+  if (corsOrigin === "*") {
+    log.warn(
+      'CORS_ORIGIN="*" is redundant; leave it unset for open access without credentials',
+    );
+  }
+}


### PR DESCRIPTION
## 本 PR 包含四個工作流

### WS1 — 音量自動平衡重構

舊的靜態每首歌衰減係數只在切歌時作用一次,無法修正歌曲內部忽大忽小或安靜歌曲沒有增益的問題。

**改動**:
- 以 mpv `dynaudnorm=f=400:g=15:m=5:r=0.8:p=0.9` 取代靜態路徑;RMS 模式 + 3 秒高斯平滑即時調整增益,歌曲內部與歌曲之間皆有效
- 切換開關透過 mpv IPC `af set/clr` 即時生效,不需重新播放
- 移除 `music.service.getTrackLoudness`、`queue.service` 靜態增益路徑(防止雙重衰減)
- 將既有 `VolumeNormalizationControl` 接入桌面 `PlayerSection` 與手機 `MobileNowPlayingSheet`

### WS2 — Discovery 個人化

冷啟動時 TopRequestedRail 會顯示空白;沒有個人化內容,覺得「沒用」。

**改動**:
- 新增「最近常聽」(近 30 天點播紀錄)與「為你推薦」(top-3 種子 → YouTube up-next 延伸)兩個區塊,排在市場內容之前
- 15 分鐘推薦快取;單一種子失敗僅降級不中斷
- 冷啟動修正:無點播紀錄時不渲染空白熱門點播卡
- `DiscoverSection` 新增 `origin?: "personal" | "market"`

### WS3 — 安全修補 + 生產韌性

- **CORS**:`CORS_ORIGIN` 環境變數白名單;wildcard 模式移除 `credentials: true`
- **yt-dlp 完整性**:Dockerfile 新增 SHA-256 校驗步驟
- **`GET /api/health`**:供 docker-compose healthcheck 與外部監控使用
- **docker-compose healthcheck**:interval 30s / timeout 5s / retries 3
- **`.env.example`**:列出全部環境變數含說明
- **啟動驗證**:`src/utils/env.ts validateEnvironment()` 偵測常見設定錯誤,以 warn 提示不中斷
- **優雅關機**:SIGINT/SIGTERM → `server.stop(); process.exit(0)`

### WS4 — 自建精簡 CI

PR #37 依賴 self-hosted runner / Harbor / K8s / Argo CD 等外部設施,不能直接合併。

**改動**:
- `.github/workflows/ci.yml`:ubuntu-latest — backend typecheck+test / frontend build / hadolint / dependency-review-action
- 保留現有 `docker-image.yml` 不動

---

## 測試

- `bun test src/__tests__`:222 pass / 0 fail
- `bun run typecheck`:clean
- `cd frontend && npm run build`:clean
- 本機實測:dynaudnorm IPC 即時切換確認、Discovery feed 含 personal-recent / personal-for-you、`/api/health` 回傳 `version: 0.8.0`、CORS wildcard/whitelist 兩種模式行為正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)